### PR TITLE
feat: add context parameter for custom system prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,44 @@ result = transcribe(
 
 Status: greedy parity verified, but 0.53-0.55x on short/10s clips. Not enabled by default until benchmark evidence shows net speed wins.
 
+### Domain vocabulary context
+
+When transcribing specialized audio — earnings calls, medical dictation, legal
+proceedings — the model can confuse rare terms with more common homophones.
+The `context` parameter lets you provide a hint: a string of domain-specific
+words or phrases that gets injected into the system prompt, nudging the decoder
+toward the correct vocabulary.
+
+This matches the official Qwen3-ASR `context` API. The format is
+space-separated terms:
+
+```python
+# Finance: avoids "e-bit-da" → "EBITDA", "FX" not "effects", etc.
+result = transcribe("earnings-call.wav", context="EBITDA non-GAAP FX hedging")
+
+# Medical
+result = transcribe("consult.wav", context="metformin HbA1c nephropathy")
+
+# Also works with streaming
+state = init_streaming(context="EBITDA non-GAAP FX hedging")
+```
+
+```bash
+mlx-qwen3-asr earnings-call.wav --context "EBITDA non-GAAP FX hedging"
+```
+
+For batch transcription, pass a list of per-audio context strings:
+
+```python
+results = transcribe_batch(
+    [audio_en, audio_zh],
+    context=["EBITDA non-GAAP", "交易 停滞"],
+)
+```
+
+When omitted, the system prompt is empty (matching the official default) — no
+domain bias is applied.
+
 ### Streaming
 
 Rolling decode implementation for near-real-time transcription:
@@ -553,7 +591,7 @@ Optional microphone flags: `--mic-device`, `--mic-duration-sec`, `--mic-sample-r
 
 ## API reference
 
-### `transcribe(audio, *, model, draft_model, language, return_timestamps, diarize, diarization_num_speakers, diarization_min_speakers, diarization_max_speakers, return_chunks, forced_aligner, dtype, max_new_tokens, num_draft_tokens, verbose, on_progress)`
+### `transcribe(audio, *, model, draft_model, context, language, return_timestamps, diarize, diarization_num_speakers, diarization_min_speakers, diarization_max_speakers, return_chunks, forced_aligner, dtype, max_new_tokens, num_draft_tokens, verbose, on_progress)`
 
 Transcribe audio to text. Accepts a file path, numpy array, `mx.array`, or `(array, sample_rate)` tuple. Returns a `TranscriptionResult`.
 

--- a/README.md
+++ b/README.md
@@ -641,8 +641,8 @@ Audio (16kHz mono)
   → Windowed transformer encoder (18 or 24 layers, hybrid dense/segmented attention)
   → LayerNorm + GELU projection → audio features
 
-Chat-template prompt:
-  <|im_start|>system\nYou are a helpful assistant.<|im_end|>
+Chat-template prompt (context is optional domain vocabulary, empty by default):
+  <|im_start|>system\n{context}<|im_end|>
   <|im_start|>user\n<|audio_start|><|audio_pad|>*N<|audio_end|><|im_end|>
   <|im_start|>assistant\n
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,11 +192,16 @@ Conv2d weights: transpose (out, in, kH, kW) -> (out, kH, kW, in) via transpose(0
 
 ```
 <|im_start|>system
-You are a helpful assistant.<|im_end|>
+{context}<|im_end|>
 <|im_start|>user
 <|audio_start|><|audio_pad|>...(N times)...<|audio_pad|><|audio_end|>
 <|im_start|>assistant
 ```
+
+The `context` string is injected as the system message content. It defaults to
+empty (`""`), matching the official Qwen3-ASR implementation. Pass
+space-separated domain terms (e.g., `"交易 停滞"`) to bias the decoder toward
+specialized vocabulary.
 
 Output format: `language {detected_language}<asr_text>{transcription text}`
 

--- a/mlx_qwen3_asr/cli.py
+++ b/mlx_qwen3_asr/cli.py
@@ -284,6 +284,15 @@ def main():
         help=f"Model name or path (default: {DEFAULT_MODEL_ID})",
     )
     parser.add_argument(
+        "--context",
+        default="",
+        help=(
+            "Domain-specific context string for the system prompt. "
+            "Provide space-separated terms (e.g., '交易 停滞') to bias "
+            "transcription toward domain vocabulary."
+        ),
+    )
+    parser.add_argument(
         "--language",
         default=None,
         help="Force language (e.g., English, Chinese)",
@@ -623,6 +632,7 @@ def main():
         chunk_samples = max(1, int(args.stream_chunk_sec * args.mic_sample_rate))
         state = init_streaming(
             model=args.model,
+            context=args.context,
             chunk_size_sec=args.stream_chunk_sec,
             max_context_sec=args.stream_max_context_sec,
             sample_rate=args.mic_sample_rate,
@@ -722,6 +732,7 @@ def main():
                     audio=audio_path,
                     model=args.model,
                     draft_model=args.draft_model,
+                    context=args.context,
                     language=args.language,
                     return_timestamps=effective_timestamps,
                     diarize=args.diarize,
@@ -741,6 +752,7 @@ def main():
                 chunk_samples = max(1, int(args.stream_chunk_sec * SAMPLE_RATE))
                 state = init_streaming(
                     model=args.model,
+                    context=args.context,
                     chunk_size_sec=args.stream_chunk_sec,
                     max_context_sec=args.stream_max_context_sec,
                     sample_rate=SAMPLE_RATE,

--- a/mlx_qwen3_asr/session.py
+++ b/mlx_qwen3_asr/session.py
@@ -69,6 +69,7 @@ class Session:
         audio: AudioInput,
         *,
         draft_model: Optional[Union[str, Qwen3ASRModel]] = None,
+        context: str = "",
         language: Optional[str] = None,
         return_timestamps: bool = False,
         diarize: bool = False,
@@ -84,6 +85,7 @@ class Session:
     ) -> TranscriptionResult:
         """Transcribe audio using this session's loaded model/tokenizer."""
         options = _build_transcribe_options(
+            context=context,
             language=language,
             return_timestamps=return_timestamps,
             diarize=diarize,
@@ -120,6 +122,7 @@ class Session:
             tokenizer=self.tokenizer,
             dtype=self.dtype,
             draft_model_obj=draft_model_obj,
+            context=options.context,
             language=options.language,
             aligner=aligner,
             return_timestamps=options.return_timestamps,
@@ -136,6 +139,7 @@ class Session:
         audio: AudioInput,
         *,
         draft_model: Optional[Union[str, Qwen3ASRModel]] = None,
+        context: str = "",
         language: Optional[str] = None,
         return_timestamps: bool = False,
         diarize: bool = False,
@@ -151,6 +155,7 @@ class Session:
     ) -> TranscriptionResult:
         """Async wrapper for ``transcribe`` using ``asyncio.to_thread``."""
         options = _build_transcribe_options(
+            context=context,
             language=language,
             return_timestamps=return_timestamps,
             diarize=diarize,
@@ -175,6 +180,7 @@ class Session:
     def init_streaming(
         self,
         *,
+        context: str = "",
         language: Optional[str] = None,
         unfixed_chunk_num: int = 2,
         unfixed_token_num: int = 5,
@@ -192,6 +198,7 @@ class Session:
         """Create streaming state bound to this session's model settings."""
         return streaming_mod.init_streaming(
             model=self.model_id,
+            context=context,
             language=language,
             unfixed_chunk_num=unfixed_chunk_num,
             unfixed_token_num=unfixed_token_num,

--- a/mlx_qwen3_asr/streaming.py
+++ b/mlx_qwen3_asr/streaming.py
@@ -61,6 +61,7 @@ class StreamingState:
     buffer: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.float32))
     audio_accum: np.ndarray = field(default_factory=lambda: np.array([], dtype=np.float32))
     text: str = ""
+    context: str = ""
     language: str = "unknown"
     forced_language: Optional[str] = None
     chunk_id: int = 0
@@ -91,6 +92,7 @@ class StreamingState:
 
 def init_streaming(
     model: str = DEFAULT_MODEL_ID,
+    context: str = "",
     unfixed_chunk_num: int = UNFIXED_CHUNK_NUM,
     unfixed_token_num: int = UNFIXED_TOKEN_NUM,
     chunk_size_sec: float = 2.0,
@@ -150,6 +152,7 @@ def init_streaming(
         mode = "accuracy" if tail_refine else "latency"
 
     return StreamingState(
+        context=context or "",
         unfixed_chunk_num=int(unfixed_chunk_num),
         unfixed_token_num=int(unfixed_token_num),
         chunk_size_samples=int(chunk_size_sec * sample_rate),
@@ -275,6 +278,7 @@ def finish_streaming(
         refined = transcribe(
             audio=refine_audio,
             model=decode_model,
+            context=state.context,
             max_new_tokens=state.max_new_tokens,
             verbose=False,
         )
@@ -411,6 +415,7 @@ def _decode_chunk_incremental(
         prompt_tokens = tokenizer.build_prompt_tokens(
             n_audio_tokens=n_audio_tokens,
             language=initial_language,
+            context=state.context,
         )
     else:
         follow_lang = state.forced_language or (
@@ -419,6 +424,7 @@ def _decode_chunk_incremental(
         prompt_tokens = tokenizer.build_followup_prompt_tokens(
             n_audio_tokens=n_audio_tokens,
             language=follow_lang,
+            context=state.context,
         )
 
     input_ids = mx.array([prompt_tokens])

--- a/mlx_qwen3_asr/tokenizer.py
+++ b/mlx_qwen3_asr/tokenizer.py
@@ -359,7 +359,7 @@ class Tokenizer:
         self.AUDIO_TOKEN_ID = vocab.get("<|audio_pad|>", 151676)
         self.AUDIO_START_TOKEN_ID = vocab.get("<|audio_start|>", 151669)
         self.AUDIO_END_TOKEN_ID = vocab.get("<|audio_end|>", 151670)
-        self._system_tokens = self.encode("system\nYou are a helpful assistant.")
+        self._system_prefix_tokens = self.encode("system\n")
         self._user_tokens = self.encode("user\n")
         self._assistant_tokens = self.encode("assistant\n")
         self._newline_id = self.encode("\n")[0]
@@ -374,12 +374,13 @@ class Tokenizer:
         self,
         n_audio_tokens: int,
         language: Optional[str] = None,
+        context: str = "",
     ) -> list[int]:
         """Build chat-template prompt with audio placeholder tokens.
 
-        Prompt template:
+        Prompt template (matching official Qwen3-ASR chat_template.json):
             <|im_start|>system
-            You are a helpful assistant.<|im_end|>
+            {context}<|im_end|>
             <|im_start|>user
             <|audio_start|><|audio_pad|>...(N times)...<|audio_pad|><|audio_end|><|im_end|>
             <|im_start|>assistant
@@ -391,13 +392,19 @@ class Tokenizer:
         Args:
             n_audio_tokens: Number of audio feature tokens to placeholder
             language: Optional language to force (e.g., "English", "Chinese")
+            context: Domain-specific context string for the system prompt
+                (e.g., space-separated terms like "交易 停滞" to bias
+                transcription toward domain vocabulary). Empty string by
+                default, matching the official Qwen3-ASR implementation.
 
         Returns:
             List of token IDs forming the complete prompt
         """
         # System message
         tokens = [self.IM_START_ID]
-        tokens.extend(self._system_tokens)
+        tokens.extend(self._system_prefix_tokens)
+        if context:
+            tokens.extend(self.encode(context))
         tokens.append(self.IM_END_ID)
         tokens.append(self._newline_id)
 
@@ -426,6 +433,7 @@ class Tokenizer:
         self,
         n_audio_tokens: int,
         language: Optional[str] = None,
+        context: str = "",
     ) -> list[int]:
         """Build a follow-up chat turn for incremental streaming.
 
@@ -434,6 +442,12 @@ class Tokenizer:
             <|im_start|>user
             <|audio_start|><|audio_pad|>*N<|audio_end|><|im_end|>
             <|im_start|>assistant
+
+        Args:
+            n_audio_tokens: Number of audio feature tokens to placeholder.
+            language: Optional language to force.
+            context: Domain-specific context (currently unused in follow-up
+                turns, accepted for API consistency).
         """
         tokens = [self.IM_END_ID, self._newline_id, self.IM_START_ID]
         tokens.extend(self._user_tokens)

--- a/mlx_qwen3_asr/transcribe.py
+++ b/mlx_qwen3_asr/transcribe.py
@@ -77,6 +77,7 @@ class TranscriptionResult:
 class TranscribeOptions:
     """Shared transcribe runtime options used across sync/async/session entry points."""
 
+    context: str = ""
     language: Optional[str] = None
     return_timestamps: bool = False
     diarize: bool = False
@@ -103,6 +104,7 @@ def _join_chunk_texts(texts: list[str], language: str) -> str:
 
 def _build_transcribe_options(
     *,
+    context: str = "",
     language: Optional[str] = None,
     return_timestamps: bool = False,
     diarize: bool = False,
@@ -118,6 +120,7 @@ def _build_transcribe_options(
     on_progress: Optional[ProgressCallback] = None,
 ) -> TranscribeOptions:
     return TranscribeOptions(
+        context=context or "",
         language=language,
         return_timestamps=return_timestamps,
         diarize=diarize,
@@ -140,6 +143,7 @@ def _transcribe_options_to_kwargs(
     include_dtype: bool = True,
 ) -> dict[str, Any]:
     kwargs: dict[str, Any] = {
+        "context": options.context,
         "language": options.language,
         "return_timestamps": options.return_timestamps,
         "diarize": options.diarize,
@@ -193,6 +197,7 @@ def transcribe(
     *,
     model: Union[str, Qwen3ASRModel] = DEFAULT_MODEL_ID,
     draft_model: Optional[Union[str, Qwen3ASRModel]] = None,
+    context: str = "",
     language: Optional[str] = None,
     return_timestamps: bool = False,
     diarize: bool = False,
@@ -222,6 +227,10 @@ def transcribe(
         model: Model name/path or pre-loaded model instance
         draft_model: Optional smaller model for speculative decoding.
             Must share tokenizer/vocabulary with ``model``.
+        context: Domain-specific context string injected as the system prompt
+            content. Provide space-separated terms (e.g., ``"交易 停滞"``) to
+            bias the decoder toward domain vocabulary. Empty string by default,
+            matching the official Qwen3-ASR implementation.
         language: Force language detection (e.g., "English", "Chinese")
         return_timestamps: Whether to return word-level timestamps.
         diarize: Whether to attach speaker labels to transcript output.
@@ -240,6 +249,7 @@ def transcribe(
         TranscriptionResult with text, language, and optional segments
     """
     options = _build_transcribe_options(
+        context=context,
         language=language,
         return_timestamps=return_timestamps,
         diarize=diarize,
@@ -281,6 +291,7 @@ def transcribe(
         tokenizer=tokenizer,
         dtype=options.dtype,
         draft_model_obj=draft_model_obj,
+        context=options.context,
         language=options.language,
         aligner=aligner,
         return_timestamps=options.return_timestamps,
@@ -298,6 +309,7 @@ async def transcribe_async(
     *,
     model: Union[str, Qwen3ASRModel] = DEFAULT_MODEL_ID,
     draft_model: Optional[Union[str, Qwen3ASRModel]] = None,
+    context: str = "",
     language: Optional[str] = None,
     return_timestamps: bool = False,
     diarize: bool = False,
@@ -314,6 +326,7 @@ async def transcribe_async(
 ) -> TranscriptionResult:
     """Async wrapper for ``transcribe`` using ``asyncio.to_thread``."""
     options = _build_transcribe_options(
+        context=context,
         language=language,
         return_timestamps=return_timestamps,
         diarize=diarize,
@@ -342,6 +355,7 @@ def transcribe_batch(
     *,
     model: Union[str, Qwen3ASRModel] = DEFAULT_MODEL_ID,
     draft_model: Optional[Union[str, Qwen3ASRModel]] = None,
+    context: Union[str, list[str]] = "",
     language: Optional[str] = None,
     return_timestamps: bool = False,
     diarize: bool = False,
@@ -356,9 +370,26 @@ def transcribe_batch(
     verbose: bool = False,
     on_progress: Optional[ProgressCallback] = None,
 ) -> list[TranscriptionResult]:
-    """Transcribe multiple audio inputs while reusing loaded model/tokenizer."""
+    """Transcribe multiple audio inputs while reusing loaded model/tokenizer.
+
+    Args:
+        context: Domain-specific context string or list of per-audio context
+            strings. When a single string is given it applies to all audios.
+            When a list is given it must have the same length as *audios*.
+    """
     if not audios:
         return []
+
+    # Normalize context to per-audio list.
+    if isinstance(context, str):
+        contexts = [context or ""] * len(audios)
+    else:
+        if len(context) != len(audios):
+            raise ValueError(
+                f"context list length ({len(context)}) must match "
+                f"audios length ({len(audios)})"
+            )
+        contexts = [c or "" for c in context]
 
     options = _build_transcribe_options(
         language=language,
@@ -404,6 +435,7 @@ def transcribe_batch(
             tokenizer=tokenizer,
             dtype=options.dtype,
             draft_model_obj=draft_model_obj,
+            context=contexts[index - 1],
             language=options.language,
             aligner=aligner,
             return_timestamps=options.return_timestamps,
@@ -436,6 +468,7 @@ async def transcribe_batch_async(
     *,
     model: Union[str, Qwen3ASRModel] = DEFAULT_MODEL_ID,
     draft_model: Optional[Union[str, Qwen3ASRModel]] = None,
+    context: Union[str, list[str]] = "",
     language: Optional[str] = None,
     return_timestamps: bool = False,
     diarize: bool = False,
@@ -466,12 +499,16 @@ async def transcribe_batch_async(
         verbose=verbose,
         on_progress=on_progress,
     )
+    kwargs = _transcribe_options_to_kwargs(options)
+    # Override scalar context from options with the original (possibly list)
+    # context so per-audio context propagates correctly.
+    kwargs["context"] = context
     return await asyncio.to_thread(
         transcribe_batch,
         audios,
         model=model,
         draft_model=draft_model,
-        **_transcribe_options_to_kwargs(options),
+        **kwargs,
     )
 
 
@@ -580,6 +617,7 @@ def _transcribe_loaded_components(
     tokenizer: Tokenizer,
     dtype: mx.Dtype,
     draft_model_obj: Optional[Qwen3ASRModel],
+    context: str = "",
     language: Optional[str],
     aligner: Optional[ForcedAligner],
     return_timestamps: bool,
@@ -658,6 +696,7 @@ def _transcribe_loaded_components(
         prompt_tokens = tokenizer.build_prompt_tokens(
             n_audio_tokens=n_audio_tokens,
             language=forced_language,
+            context=context,
         )
         input_ids = mx.array([prompt_tokens])
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -435,7 +435,7 @@ class TestFinishStreaming:
 
         calls = {"full": 0}
 
-        def fake_transcribe(audio, model, max_new_tokens, verbose):  # noqa: ANN001
+        def fake_transcribe(audio, model, max_new_tokens, verbose, context=""):  # noqa: ANN001
             calls["full"] += 1
             return SimpleNamespace(text="same text plus tail", language="English")
 
@@ -464,7 +464,7 @@ class TestFinishStreaming:
 
         seen = {}
 
-        def fake_transcribe(audio, model, max_new_tokens, verbose):  # noqa: ANN001
+        def fake_transcribe(audio, model, max_new_tokens, verbose, context=""):  # noqa: ANN001
             seen["len"] = len(np.asarray(audio))
             return SimpleNamespace(text="tail", language="English")
 
@@ -590,10 +590,10 @@ class TestIncrementalDecode:
         class _FakeTokenizer:
             EOS_TOKEN_IDS = [2]
 
-            def build_prompt_tokens(self, n_audio_tokens, language=None):  # noqa: ANN001
+            def build_prompt_tokens(self, n_audio_tokens, language=None, context=""):  # noqa: ANN001
                 return [11, 12]
 
-            def build_followup_prompt_tokens(self, n_audio_tokens, language=None):  # noqa: ANN001
+            def build_followup_prompt_tokens(self, n_audio_tokens, language=None, context=""):  # noqa: ANN001
                 return [13]
 
             def decode(self, ids):  # noqa: ANN001

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -295,3 +295,51 @@ def test_native_tokenizer_skip_special_tokens(tmp_path):
 
     ids = [151669, 151676, 151670, 151704]
     assert tok.decode(ids, skip_special_tokens=True) == "<asr_text>"
+
+
+class TestBuildPromptTokensContext:
+    """Test that context parameter flows into the system message."""
+
+    def test_default_context_produces_empty_system_content(self, tmp_path):
+        model_dir = _write_min_tokenizer_files(tmp_path)
+        tok = tokmod.Tokenizer(model_dir)
+        tokens = tok.build_prompt_tokens(n_audio_tokens=2)
+        # System message: <|im_start|> + "system\n" + <|im_end|>
+        assert tokens[0] == 151644  # <|im_start|>
+        # The next tokens should be the system prefix immediately followed by
+        # <|im_end|> (no content tokens between them).
+        im_end_idx = tokens.index(151645)
+        system_prefix = tok.encode("system\n")
+        assert tokens[1 : 1 + len(system_prefix)] == system_prefix
+        # With empty context, <|im_end|> follows right after system prefix.
+        assert im_end_idx == 1 + len(system_prefix)
+
+    def test_custom_context_injects_tokens(self, tmp_path):
+        model_dir = _write_min_tokenizer_files(tmp_path)
+        tok = tokmod.Tokenizer(model_dir)
+        tokens_empty = tok.build_prompt_tokens(n_audio_tokens=2, context="")
+        tokens_ctx = tok.build_prompt_tokens(n_audio_tokens=2, context="hello")
+        # Custom context should produce more tokens in the system message.
+        assert len(tokens_ctx) > len(tokens_empty)
+        # The context tokens should appear between system prefix and <|im_end|>.
+        ctx_encoded = tok.encode("hello")
+        system_prefix = tok.encode("system\n")
+        start = 1 + len(system_prefix)
+        assert tokens_ctx[start : start + len(ctx_encoded)] == ctx_encoded
+
+    def test_followup_accepts_context_kwarg(self, tmp_path):
+        model_dir = _write_min_tokenizer_files(tmp_path)
+        tok = tokmod.Tokenizer(model_dir)
+        # Should not raise — context is accepted but not used in follow-up.
+        tokens = tok.build_followup_prompt_tokens(
+            n_audio_tokens=2, context="hello"
+        )
+        assert isinstance(tokens, list)
+
+    def test_audio_tokens_present_with_context(self, tmp_path):
+        model_dir = _write_min_tokenizer_files(tmp_path)
+        tok = tokmod.Tokenizer(model_dir)
+        tokens = tok.build_prompt_tokens(n_audio_tokens=3, context="hello world")
+        assert tokens.count(151676) == 3  # <|audio_pad|> count
+        assert 151669 in tokens  # <|audio_start|>
+        assert 151670 in tokens  # <|audio_end|>

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -31,7 +31,9 @@ class _DummyTokenizer:
     def __init__(self, model_path: str):
         self.model_path = model_path
 
-    def build_prompt_tokens(self, n_audio_tokens: int, language: str | None = None) -> list[int]:
+    def build_prompt_tokens(
+        self, n_audio_tokens: int, language: str | None = None, context: str = "",
+    ) -> list[int]:
         return [1, 2, 3]
 
     def decode(self, ids: list[int]) -> str:
@@ -42,9 +44,13 @@ class _RecordingLanguageTokenizer(_DummyTokenizer):
     def __init__(self, model_path: str):
         super().__init__(model_path)
         self.languages: list[str | None] = []
+        self.contexts: list[str] = []
 
-    def build_prompt_tokens(self, n_audio_tokens: int, language: str | None = None) -> list[int]:
+    def build_prompt_tokens(
+        self, n_audio_tokens: int, language: str | None = None, context: str = "",
+    ) -> list[int]:
         self.languages.append(language)
+        self.contexts.append(context)
         return [1, 2, 3]
 
 
@@ -378,6 +384,137 @@ def test_transcribe_canonicalizes_forced_language(monkeypatch):
     assert tokenizer.languages == ["German"]
     assert result.language == "German"
     assert result.text == "hallo welt"
+
+
+def test_transcribe_passes_context_to_tokenizer(monkeypatch):
+    tmod = importlib.import_module("mlx_qwen3_asr.transcribe")
+    tokenizer = _RecordingLanguageTokenizer("repo/a")
+
+    class _RecordingTokenizerHolder:
+        @staticmethod
+        def get(model_path: str):
+            return tokenizer
+
+    monkeypatch.setattr(tmod, "_TokenizerHolder", _RecordingTokenizerHolder)
+    monkeypatch.setattr(tmod._ModelHolder, "get", lambda *a, **k: (_DummyModel(), None))
+    monkeypatch.setattr(
+        tmod._ModelHolder,
+        "get_resolved_path",
+        lambda path, dtype=mx.float16: path,
+    )
+    monkeypatch.setattr(
+        tmod,
+        "compute_features",
+        lambda audio: (mx.zeros((1, 128, 100), dtype=mx.float32), mx.array([100], dtype=mx.int32)),
+    )
+    monkeypatch.setattr(tmod, "generate", lambda **kwargs: [10, 11, 12])
+
+    result = transcribe(np.zeros(3200, dtype=np.float32), context="交易 停滞")
+
+    assert tokenizer.contexts == ["交易 停滞"]
+    assert result.text == "hello world"
+
+
+def test_transcribe_default_context_is_empty(monkeypatch):
+    tmod = importlib.import_module("mlx_qwen3_asr.transcribe")
+    tokenizer = _RecordingLanguageTokenizer("repo/a")
+
+    class _RecordingTokenizerHolder:
+        @staticmethod
+        def get(model_path: str):
+            return tokenizer
+
+    monkeypatch.setattr(tmod, "_TokenizerHolder", _RecordingTokenizerHolder)
+    monkeypatch.setattr(tmod._ModelHolder, "get", lambda *a, **k: (_DummyModel(), None))
+    monkeypatch.setattr(
+        tmod._ModelHolder,
+        "get_resolved_path",
+        lambda path, dtype=mx.float16: path,
+    )
+    monkeypatch.setattr(
+        tmod,
+        "compute_features",
+        lambda audio: (mx.zeros((1, 128, 100), dtype=mx.float32), mx.array([100], dtype=mx.int32)),
+    )
+    monkeypatch.setattr(tmod, "generate", lambda **kwargs: [10, 11, 12])
+
+    transcribe(np.zeros(3200, dtype=np.float32))
+
+    assert tokenizer.contexts == [""]
+
+
+def test_transcribe_batch_per_audio_context(monkeypatch):
+    tmod = importlib.import_module("mlx_qwen3_asr.transcribe")
+    tokenizer = _RecordingLanguageTokenizer("repo/a")
+
+    class _RecordingTokenizerHolder:
+        @staticmethod
+        def get(model_path: str):
+            return tokenizer
+
+    monkeypatch.setattr(tmod, "_TokenizerHolder", _RecordingTokenizerHolder)
+    monkeypatch.setattr(tmod._ModelHolder, "get", lambda *a, **k: (_DummyModel(), None))
+    monkeypatch.setattr(
+        tmod._ModelHolder,
+        "get_resolved_path",
+        lambda path, dtype=mx.float16: path,
+    )
+    monkeypatch.setattr(
+        tmod,
+        "compute_features",
+        lambda audio: (mx.zeros((1, 128, 100), dtype=mx.float32), mx.array([100], dtype=mx.int32)),
+    )
+    monkeypatch.setattr(tmod, "generate", lambda **kwargs: [10, 11, 12])
+
+    results = transcribe_batch(
+        [np.zeros(3200, dtype=np.float32), np.zeros(3200, dtype=np.float32)],
+        context=["ctx_a", "ctx_b"],
+    )
+
+    assert len(results) == 2
+    assert tokenizer.contexts == ["ctx_a", "ctx_b"]
+
+
+def test_transcribe_batch_broadcasts_single_context(monkeypatch):
+    tmod = importlib.import_module("mlx_qwen3_asr.transcribe")
+    tokenizer = _RecordingLanguageTokenizer("repo/a")
+
+    class _RecordingTokenizerHolder:
+        @staticmethod
+        def get(model_path: str):
+            return tokenizer
+
+    monkeypatch.setattr(tmod, "_TokenizerHolder", _RecordingTokenizerHolder)
+    monkeypatch.setattr(tmod._ModelHolder, "get", lambda *a, **k: (_DummyModel(), None))
+    monkeypatch.setattr(
+        tmod._ModelHolder,
+        "get_resolved_path",
+        lambda path, dtype=mx.float16: path,
+    )
+    monkeypatch.setattr(
+        tmod,
+        "compute_features",
+        lambda audio: (mx.zeros((1, 128, 100), dtype=mx.float32), mx.array([100], dtype=mx.int32)),
+    )
+    monkeypatch.setattr(tmod, "generate", lambda **kwargs: [10, 11, 12])
+
+    results = transcribe_batch(
+        [np.zeros(3200, dtype=np.float32), np.zeros(3200, dtype=np.float32)],
+        context="shared_ctx",
+    )
+
+    assert len(results) == 2
+    assert tokenizer.contexts == ["shared_ctx", "shared_ctx"]
+
+
+def test_transcribe_batch_context_length_mismatch():
+    import pytest
+
+    with pytest.raises(ValueError, match="context list length"):
+        transcribe_batch(
+            [np.zeros(3200, dtype=np.float32)],
+            context=["a", "b"],
+        )
 
 
 def test_transcribe_uses_speculative_path_when_draft_model_is_set(monkeypatch):


### PR DESCRIPTION
## What & why

When transcribing specialized audio — earnings calls, medical dictation, legal proceedings — the model can confuse rare terms with common homophones. The official Qwen3-ASR addresses this with a `context` parameter: a string of domain-specific words injected into the system prompt that nudges the decoder toward the correct vocabulary.

Our implementation was missing this. This PR adds full `context` support across the entire API surface, matching the official Qwen3-ASR behavior.

Closes #2

## What changed

**The core idea is simple**: the system message in the chat template is now caller-controlled.

```
<|im_start|>system\n{context}<|im_end|>     (empty by default)
```

The `context` parameter is threaded through every public entry point:

- `transcribe()`, `transcribe_async()` — `context: str = ""`
- `transcribe_batch()`, `transcribe_batch_async()` — `context: Union[str, list[str]] = ""` (per-audio context with length validation)
- `Session.transcribe()`, `Session.transcribe_async()`, `Session.init_streaming()` — `context: str = ""`
- `init_streaming()` — stored in `StreamingState`, used for all chunks + tail refinement
- CLI — `--context "EBITDA non-GAAP FX hedging"`

Default is `""` (empty string), matching the official Qwen3-ASR.

## Usage

```python
# Finance terms the model might otherwise mishear
result = transcribe("earnings-call.wav", context="EBITDA non-GAAP FX hedging")

# Per-audio context in batch
results = transcribe_batch(
    [audio_en, audio_zh],
    context=["EBITDA non-GAAP", "交易 停滞"],
)

# Streaming
state = init_streaming(context="metformin HbA1c nephropathy")
```

## Test plan
- 478 tests pass (9 new), 2 skipped
- New tests cover: tokenizer context injection, empty default, transcribe flow-through, batch per-audio distribution, batch single-string broadcast, batch length mismatch validation
- Ruff clean, docs updated (ARCHITECTURE.md, README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-facing --context option and context parameter across transcription, batch, async, and streaming flows to inject per-audio or global domain strings into prompts (defaults to empty).

* **Documentation**
  * Updated docs and examples (architecture, API, finance/medical, streaming, batch) to show and explain the new context parameter and its usage.

* **Tests**
  * Added and updated tests to cover context propagation and per-audio/context broadcasting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->