### PR TITLE
feat: built-in transcription server with OpenAI API compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,12 @@ Ground-up MLX reimplementation of Qwen3-ASR. Same HuggingFace weights, same outp
 - **Fast** — Metal-optimized inference, sub-200ms latency on short clips
 - **Production-grade** — bounds checks, multi-slot model cache, Session API, proper error paths
 - **No PyTorch in the core path** — core ASR pipeline (audio → mel → encoder → decoder → text) must never import torch
+- **Built-in server** — `mlx-qwen3-asr serve` turns any Mac into a transcription API endpoint (optional `[serve]` extra)
 
 ### What this is NOT
 
 - Not a multi-model toolkit (that's mlx-audio)
 - Not a training framework
-- Not a server/API — library + CLI only
 
 ## Current Status (v0.1.0)
 
@@ -29,7 +29,8 @@ Published on PyPI. 441 tests (440 passed, 1 skipped). Core pipeline stable.
 
 ### What's next
 
-1. **Swift port** — once Python proves every decision, native Swift+MLX for apps and system integration (separate repo: `qwen3-asr-swift`)
+1. **Transcription server** — built-in HTTP server (`mlx-qwen3-asr serve`) with async jobs, API key auth, backpressure. See `docs/server/` for spec.
+2. **Swift port** — once Python proves every decision, native Swift+MLX for apps and system integration (separate repo: `qwen3-asr-swift`)
 
 ### What's done
 
@@ -88,7 +89,8 @@ mlx_qwen3_asr/
 ├── forced_aligner.py    # MLX forced aligner + LIS timestamp correction
 ├── streaming.py         # KV-cache streaming with context trimming + tail refinement
 ├── writers.py           # Output format writers (txt, srt, vtt, json, tsv)
-├── cli.py               # CLI entry point
+├── server.py            # Optional HTTP server (FastAPI, async jobs, API key auth)
+├── cli.py               # CLI entry point (transcribe + serve subcommands)
 └── assets/
     ├── mel_filters.npz        # Pre-computed 128-bin Slaney mel filterbanks
     └── korean_dict_jieba.dict # Korean tokenizer dictionary for aligner
@@ -104,6 +106,7 @@ mlx_qwen3_asr/
 | Weight format | safetensors | MLX ecosystem standard |
 | Mel spectrogram | Custom MLX (default) | HF fallback for non-16kHz only |
 | Forced aligner | Native MLX (default) | PyTorch `qwen-asr` as optional fallback |
+| Server | FastAPI + uvicorn (optional `[serve]`) | Async, lightweight, OpenAPI docs free |
 
 ## Code Conventions
 
@@ -215,6 +218,10 @@ PyPI account: moona3k@gmail.com. Token scope: `mlx-qwen3-asr` project. Pure Pyth
 | `docs/BENCHMARKING.md` | Runtime measurement protocol and methodology |
 | `docs/memory/operating-memory.md` | Agent memory front door (protocol + compacted guidance) |
 | `docs/memory/events/` | Append-only implementation memory events |
+| `docs/server/README.md` | Server feature overview and quick start |
+| `docs/server/API-SPEC.md` | Full server API specification |
+| `docs/server/ADR-001-transcription-server.md` | Server architecture decision record |
+| `docs/server/DEPLOYMENT.md` | Server deployment and operations guide |
 
 ## Continuous Learning
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -295,3 +295,23 @@ local-only prompt feature that diverges from upstream batch/streaming semantics.
   and avoids local prompt drift.
 - Keeping one prompt contract across Python API, Session API, streaming, and
   CLI reduces surprise and keeps parity reasoning straightforward.
+
+## Decision 24: Built-in HTTP Transcription Server as Optional Feature
+
+**Choice:** Ship `server.py` inside `mlx_qwen3_asr` with FastAPI + uvicorn as
+optional `[serve]` dependencies. Activated via `mlx-qwen3-asr serve`.
+**Alternatives:** (1) separate package (`mlx-qwen3-asr-server`), (2) no server
+at all — library + CLI only.
+
+**Rationale:**
+- Apple Silicon Macs are efficient inference machines; users want to turn them
+  into transcription endpoints accessible from any device on the network or
+  internet.
+- In-package keeps it one repo, one install. Optional deps keep the core lean.
+- Single-tenant, API-key auth, async job model (POST returns job ID, poll for
+  result), sequential FIFO processing, in-memory job store with TTL.
+- v1 scope deliberately narrow: file upload only (no URL ingestion — SSRF risk),
+  no WebSocket streaming, no job cancellation, no multi-tenancy.
+- Server response mirrors `TranscriptionResult` directly — no translation layer.
+
+**Full spec:** `docs/server/` (ADR, API spec, deployment guide).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -108,12 +108,13 @@ Performance progress:
 Near-term work should remain correctness-gated and benchmark-driven:
 
 1. **Transcription server** (`mlx-qwen3-asr serve`)
-- Status: spec complete (`docs/server/`). Implementation next.
+- Status: implemented and shipped. 46 tests, hardened from external review.
 - Scope: FastAPI + uvicorn behind `[serve]` optional extra. Single-tenant,
   API key auth, async job model, sequential FIFO, in-memory job store with TTL.
-  File upload only (no URL ingestion in v1). Backpressure via max queue depth.
-- Gate: server starts, accepts uploads, returns correct transcriptions,
-  handles auth/rate-limiting/backpressure. Integration tests.
+  File upload only (no URL ingestion in v1). Backpressure via atomic queue admission.
+  Job ownership enforced per API key. Error sanitization. Config validation.
+- Gate: passed — server starts, accepts uploads, returns correct transcriptions,
+  handles auth/rate-limiting/backpressure/job-isolation. Integration tests pass.
 - Spec: `docs/server/ADR-001-transcription-server.md`, `docs/server/API-SPEC.md`
 
 2. Native MLX forced aligner (timestamps) quality hardening

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,7 +107,16 @@ Performance progress:
 
 Near-term work should remain correctness-gated and benchmark-driven:
 
-1. Native MLX forced aligner (timestamps) quality hardening
+1. **Transcription server** (`mlx-qwen3-asr serve`)
+- Status: spec complete (`docs/server/`). Implementation next.
+- Scope: FastAPI + uvicorn behind `[serve]` optional extra. Single-tenant,
+  API key auth, async job model, sequential FIFO, in-memory job store with TTL.
+  File upload only (no URL ingestion in v1). Backpressure via max queue depth.
+- Gate: server starts, accepts uploads, returns correct transcriptions,
+  handles auth/rate-limiting/backpressure. Integration tests.
+- Spec: `docs/server/ADR-001-transcription-server.md`, `docs/server/API-SPEC.md`
+
+2. Native MLX forced aligner (timestamps) quality hardening
 - Goal: continue quality hardening now that runtime PyTorch dependency is removed.
 - Gate: word-level timing quality must be competitive with current `qwen-asr` backend.
 

--- a/docs/server/ADR-001-transcription-server.md
+++ b/docs/server/ADR-001-transcription-server.md
@@ -1,0 +1,69 @@
+# ADR-001: Built-in Transcription Server
+
+**Status:** Accepted
+**Date:** 2026-03-20
+
+## Context
+
+Apple Silicon Macs are efficient inference machines for MLX workloads. Users want
+to turn their Macs into transcription endpoints — accepting audio from any device
+on the network (or internet) and returning text. Today `mlx-qwen3-asr` is a
+library + CLI; there is no way to serve transcription over HTTP without writing
+custom glue code.
+
+## Decision
+
+Ship a built-in HTTP transcription server inside the `mlx_qwen3_asr` package as
+an optional feature, activated via `pip install mlx-qwen3-asr[serve]` and launched
+with `mlx-qwen3-asr serve`.
+
+### Design choices
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| **Packaging** | In-package, optional deps | One repo, one install. Server is a natural extension of the CLI, not a separate product. Optional deps keep the core lean. |
+| **Framework** | FastAPI + uvicorn | Async, lightweight, battle-tested. File upload handling is first-class. OpenAPI docs come free. |
+| **Tenancy** | Single-tenant | Your Macs, your API keys. No user management, no billing, no isolation concerns. |
+| **Auth** | API key (Bearer token) | Simple, sufficient for single-tenant internet-facing use. Keys configured at startup. |
+| **Job model** | Async jobs (POST returns job ID, poll for result) | Uniform model for short and long audio. Avoids hanging HTTP connections on long files. |
+| **Audio input** | File upload (multipart) + URL reference | Covers direct upload and cloud storage references. No WebSocket streaming in v1. |
+| **Rate limiting** | Per-key, requests/minute | Basic abuse protection for internet-facing deployment. |
+| **Model lifecycle** | Load on startup, keep in memory | Session object persists across requests. No per-request model loading. No hot-swap in v1. |
+| **Job storage** | In-memory (dict) | Simple, no external deps. Jobs expire after configurable TTL. Acceptable for single-process server. |
+
+### What this is NOT
+
+- Not multi-tenant — no user accounts, no per-user quotas
+- Not a distributed job queue — single process, in-memory state
+- Not a WebSocket streaming server — async jobs only in v1
+- Not a production deployment platform — no TLS termination, no process management (use a reverse proxy + systemd/launchd for that)
+
+## Consequences
+
+### Positive
+
+- Any Mac becomes a transcription endpoint with one command
+- Clients on any platform (phones, other machines, scripts) can use the ASR capability
+- Aligns with "one-command setup" project philosophy
+- No new repos or packages to maintain
+
+### Negative
+
+- Server deps (FastAPI, uvicorn) added to optional dependency surface
+- In-memory job store means jobs are lost on restart
+- Single-process model means throughput is limited to one transcription at a time per worker
+
+### Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Scope creep toward "real" server product | Keep the server as a convenience feature. No multi-tenancy, no databases, no orchestration. |
+| Memory pressure from large audio files | File size cap enforced at upload. Configurable max duration. |
+| API key leakage | Keys are local config, not stored in code. Docs recommend reverse proxy + TLS for internet exposure. |
+
+## Alternatives considered
+
+1. **Separate package** (`mlx-qwen3-asr-server`) — cleaner separation but adds maintenance overhead and friction for users. Rejected.
+2. **gRPC instead of HTTP** — better for streaming, worse for simplicity and tooling. HTTP is universal. Rejected for v1.
+3. **Sync-only API** — simpler but blocks on long audio. Rejected in favor of uniform async job model.
+4. **WebSocket streaming** — valuable for real-time use but adds significant complexity. Deferred to v2.

--- a/docs/server/ADR-001-transcription-server.md
+++ b/docs/server/ADR-001-transcription-server.md
@@ -11,6 +11,9 @@ on the network (or internet) and returning text. Today `mlx-qwen3-asr` is a
 library + CLI; there is no way to serve transcription over HTTP without writing
 custom glue code.
 
+Note: CLAUDE.md currently says "Not a server/API — library + CLI only." This
+must be updated to reflect the new scope before merging.
+
 ## Decision
 
 Ship a built-in HTTP transcription server inside the `mlx_qwen3_asr` package as
@@ -22,14 +25,16 @@ with `mlx-qwen3-asr serve`.
 | Question | Decision | Rationale |
 |----------|----------|-----------|
 | **Packaging** | In-package, optional deps | One repo, one install. Server is a natural extension of the CLI, not a separate product. Optional deps keep the core lean. |
-| **Framework** | FastAPI + uvicorn | Async, lightweight, battle-tested. File upload handling is first-class. OpenAPI docs come free. |
+| **Framework** | FastAPI + uvicorn + python-multipart | Async, lightweight, battle-tested. File upload handling is first-class. OpenAPI docs come free. `python-multipart` required for FastAPI file uploads. |
 | **Tenancy** | Single-tenant | Your Macs, your API keys. No user management, no billing, no isolation concerns. |
-| **Auth** | API key (Bearer token) | Simple, sufficient for single-tenant internet-facing use. Keys configured at startup. |
+| **Auth** | API key (Bearer token) | Simple, sufficient for single-tenant internet-facing use. Keys configured at startup. Server refuses to start without at least one key. |
 | **Job model** | Async jobs (POST returns job ID, poll for result) | Uniform model for short and long audio. Avoids hanging HTTP connections on long files. |
-| **Audio input** | File upload (multipart) + URL reference | Covers direct upload and cloud storage references. No WebSocket streaming in v1. |
-| **Rate limiting** | Per-key, requests/minute | Basic abuse protection for internet-facing deployment. |
+| **Audio input** | File upload (multipart) only | Simple, universal, no SSRF risk. URL ingestion deferred to v2 (requires scheme allowlist, private-IP blocking, redirect limits, download timeout — too much complexity for v1). |
+| **Rate limiting** | Per-key, requests/minute | Basic abuse protection for internet-facing deployment. `GET /jobs/{id}` polling does NOT count against the rate limit bucket. |
 | **Model lifecycle** | Load on startup, keep in memory | Session object persists across requests. No per-request model loading. No hot-swap in v1. |
 | **Job storage** | In-memory (dict) | Simple, no external deps. Jobs expire after configurable TTL. Acceptable for single-process server. |
+| **Concurrency** | Sequential (FIFO) | One job at a time. Most Macs can't run parallel model inference anyway. Queue capped at configurable max depth (default 10); returns `503 Service Unavailable` when full. |
+| **Temp files** | Write uploads to `tempfile.NamedTemporaryFile`, delete after transcription completes or fails | `load_audio_np()` requires a filesystem path. Temp files are cleaned up in a `finally` block and on job TTL expiry. |
 
 ### What this is NOT
 
@@ -49,7 +54,7 @@ with `mlx-qwen3-asr serve`.
 
 ### Negative
 
-- Server deps (FastAPI, uvicorn) added to optional dependency surface
+- Server deps (FastAPI, uvicorn, python-multipart) added to optional dependency surface
 - In-memory job store means jobs are lost on restart
 - Single-process model means throughput is limited to one transcription at a time per worker
 
@@ -58,8 +63,10 @@ with `mlx-qwen3-asr serve`.
 | Risk | Mitigation |
 |------|------------|
 | Scope creep toward "real" server product | Keep the server as a convenience feature. No multi-tenancy, no databases, no orchestration. |
-| Memory pressure from large audio files | File size cap enforced at upload. Configurable max duration. |
+| Memory pressure from large audio files | File size cap enforced at upload. Configurable max audio duration. Temp files cleaned up eagerly. |
 | API key leakage | Keys are local config, not stored in code. Docs recommend reverse proxy + TLS for internet exposure. |
+| Queue starvation from long files | Max queue depth with 503 backpressure. Max audio duration enforced at submission. |
+| Temp file leaks on crash | Temp files written to system temp dir; OS cleans up on reboot. TTL expiry also cleans up. |
 
 ## Alternatives considered
 
@@ -67,3 +74,5 @@ with `mlx-qwen3-asr serve`.
 2. **gRPC instead of HTTP** — better for streaming, worse for simplicity and tooling. HTTP is universal. Rejected for v1.
 3. **Sync-only API** — simpler but blocks on long audio. Rejected in favor of uniform async job model.
 4. **WebSocket streaming** — valuable for real-time use but adds significant complexity. Deferred to v2.
+5. **URL ingestion** — convenient for cloud storage but introduces SSRF attack surface (private-IP access, metadata endpoints, localhost probing). Requires scheme allowlist, redirect limits, content-length enforcement, and download timeouts. Deferred to v2.
+6. **DELETE /jobs/{id}** — useful for cleanup but semantics are unclear when a job is actively processing (cancel inference? kill ffmpeg subprocess? just hide result?). Deferred to v2 when cancellation can be designed properly.

--- a/docs/server/API-SPEC.md
+++ b/docs/server/API-SPEC.md
@@ -200,6 +200,92 @@ The server passes through the library output as-is — no schema translation lay
 
 ---
 
+### `POST /v1/audio/transcriptions`
+
+OpenAI-compatible transcription endpoint. Drop-in replacement for the
+OpenAI Audio API — existing clients just change the base URL.
+
+**Key difference from `/transcribe`:** This endpoint is **synchronous** — it
+blocks until transcription completes and returns the result directly. No job
+queue, no polling. Best for short audio or when you need OpenAI SDK
+compatibility.
+
+**Content-Type:** `multipart/form-data`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `file` | file | yes | Audio file (wav, mp3, flac, m4a, ogg, etc.) |
+| `model` | string | no | Model identifier. Accepted for compatibility; server uses its loaded model. |
+| `language` | string | no | Language code (e.g., `en`, `ja`, `zh`). Auto-detect if omitted. |
+| `prompt` | string | no | Text to guide transcription (maps to `context` internally). |
+| `response_format` | string | no | `json` (default), `text`, `verbose_json`, `srt`, `vtt` |
+| `temperature` | float | no | Accepted for compatibility. Ignored (greedy decoding). |
+
+**Response** (`response_format=json`, default) `200 OK`:
+
+```json
+{"text": "The transcribed text."}
+```
+
+**Response** (`response_format=text`) `200 OK`:
+
+```
+The transcribed text.
+```
+
+**Response** (`response_format=verbose_json`) `200 OK`:
+
+```json
+{
+  "task": "transcribe",
+  "language": "english",
+  "duration": 5.1,
+  "text": "The transcribed text.",
+  "words": [
+    {"word": "The", "start": 0.0, "end": 0.3},
+    {"word": "transcribed", "start": 0.3, "end": 0.8},
+    {"word": "text.", "start": 0.8, "end": 1.2}
+  ]
+}
+```
+
+**Response** (`response_format=srt`) `200 OK`:
+
+```
+1
+00:00:00,000 --> 00:00:01,200
+The transcribed text.
+```
+
+**Response** (`response_format=vtt`) `200 OK`:
+
+```
+WEBVTT
+
+00:00:00.000 --> 00:00:01.200
+The transcribed text.
+```
+
+**Notes:**
+
+- `verbose_json`, `srt`, and `vtt` formats automatically enable word-level
+  timestamps (forced aligner). First use downloads the aligner model (~1.2 GB).
+- The `words` array in `verbose_json` maps OpenAI's `word` field from our
+  word-level segments. Duration is estimated from the last timestamp.
+
+**Error responses:**
+
+| Code | Condition |
+|------|-----------|
+| `400` | Invalid `response_format` |
+| `401` | Missing auth token |
+| `403` | Invalid auth token |
+| `413` | File too large |
+| `429` | Rate limit exceeded |
+| `500` | Transcription failed |
+
+---
+
 ## Job lifecycle
 
 ```
@@ -299,6 +385,34 @@ while True:
     time.sleep(1)
 
 print(data["result"]["text"])
+```
+
+### OpenAI Python SDK
+
+Existing OpenAI client code works with zero changes — just point at your Mac:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="mykey123",
+    base_url="http://localhost:8765/v1",
+)
+
+result = client.audio.transcriptions.create(
+    model="Qwen/Qwen3-ASR-0.6B",
+    file=open("meeting.wav", "rb"),
+)
+print(result.text)
+
+# With word timestamps
+result = client.audio.transcriptions.create(
+    model="Qwen/Qwen3-ASR-0.6B",
+    file=open("meeting.wav", "rb"),
+    response_format="verbose_json",
+)
+for word in result.words:
+    print(f"{word['start']:.2f}s: {word['word']}")
 ```
 
 ## Configuration defaults

--- a/docs/server/API-SPEC.md
+++ b/docs/server/API-SPEC.md
@@ -1,0 +1,286 @@
+# Transcription Server — API Specification
+
+**Version:** 1.0 (draft)
+**Date:** 2026-03-20
+
+## Overview
+
+HTTP JSON API served by `mlx-qwen3-asr serve`. Turns any Apple Silicon Mac into
+a speech-to-text endpoint.
+
+**Base URL:** `http://<host>:<port>` (default port: `8765`)
+
+## Authentication
+
+All endpoints except `GET /health` require a Bearer token:
+
+```
+Authorization: Bearer <api-key>
+```
+
+API keys are configured at server startup via `--api-key` flag or
+`MLX_ASR_API_KEY` environment variable. Multiple keys can be specified
+(comma-separated).
+
+Unauthenticated requests receive `401 Unauthorized`.
+Invalid keys receive `403 Forbidden`.
+
+## Rate Limiting
+
+Per-key rate limiting. Default: 60 requests/minute. Configurable via
+`--rate-limit`.
+
+Exceeded limits return `429 Too Many Requests` with `Retry-After` header.
+
+---
+
+## Endpoints
+
+### `GET /health`
+
+Health check. No auth required.
+
+**Response** `200 OK`:
+
+```json
+{
+  "status": "ok",
+  "model": "Qwen/Qwen3-ASR-0.6B",
+  "dtype": "float16",
+  "uptime_seconds": 3421,
+  "active_jobs": 2
+}
+```
+
+---
+
+### `POST /transcribe`
+
+Submit a transcription job. Returns immediately with a job ID.
+
+**Content-Type:** `multipart/form-data` or `application/json`
+
+#### Option A: File upload (multipart)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `audio` | file | yes | Audio file (wav, mp3, flac, m4a, ogg, etc.) |
+| `language` | string | no | ISO 639-1 language code (e.g., `en`, `ja`). Auto-detect if omitted. |
+| `timestamps` | bool | no | Include word-level timestamps. Default: `false`. |
+| `context` | string | no | Custom system prompt for domain vocabulary biasing. |
+
+#### Option B: URL reference (JSON)
+
+```json
+{
+  "url": "https://storage.example.com/meeting.wav",
+  "language": "en",
+  "timestamps": true,
+  "context": ""
+}
+```
+
+**Response** `202 Accepted`:
+
+```json
+{
+  "job_id": "j_a1b2c3d4",
+  "status": "queued",
+  "created_at": "2026-03-20T14:30:00Z"
+}
+```
+
+**Error responses:**
+
+| Code | Condition |
+|------|-----------|
+| `400` | No audio provided, unsupported format, or file exceeds size limit |
+| `401` | Missing auth token |
+| `403` | Invalid auth token |
+| `429` | Rate limit exceeded |
+| `413` | File too large (default max: 500 MB) |
+
+---
+
+### `GET /jobs/{job_id}`
+
+Poll job status and retrieve results.
+
+**Response** `200 OK` (processing):
+
+```json
+{
+  "job_id": "j_a1b2c3d4",
+  "status": "processing",
+  "created_at": "2026-03-20T14:30:00Z",
+  "progress": null
+}
+```
+
+**Response** `200 OK` (completed):
+
+```json
+{
+  "job_id": "j_a1b2c3d4",
+  "status": "completed",
+  "created_at": "2026-03-20T14:30:00Z",
+  "completed_at": "2026-03-20T14:30:12Z",
+  "result": {
+    "text": "The full transcription text here.",
+    "language": "en",
+    "duration": 45.2,
+    "segments": [
+      {
+        "start": 0.0,
+        "end": 3.5,
+        "text": "The full transcription"
+      },
+      {
+        "start": 3.5,
+        "end": 5.1,
+        "text": "text here."
+      }
+    ],
+    "words": [
+      {
+        "word": "The",
+        "start": 0.0,
+        "end": 0.3
+      }
+    ]
+  }
+}
+```
+
+`words` array is only present when `timestamps: true` was requested.
+
+**Response** `200 OK` (failed):
+
+```json
+{
+  "job_id": "j_a1b2c3d4",
+  "status": "failed",
+  "created_at": "2026-03-20T14:30:00Z",
+  "error": "Audio file is corrupted or contains no speech."
+}
+```
+
+**Error responses:**
+
+| Code | Condition |
+|------|-----------|
+| `404` | Job ID not found (expired or never existed) |
+
+---
+
+### `DELETE /jobs/{job_id}`
+
+Delete a job and its results. Useful for cleanup.
+
+**Response** `204 No Content`
+
+---
+
+## Job lifecycle
+
+```
+queued → processing → completed
+                    → failed
+```
+
+- Jobs are stored in-memory. Default TTL: 1 hour after completion.
+- Server restart clears all jobs.
+- Only one job processes at a time (sequential model inference). Queued jobs
+  wait in FIFO order.
+
+## CLI usage
+
+```bash
+# Start server
+mlx-qwen3-asr serve --port 8765 --api-key mykey123
+
+# With options
+mlx-qwen3-asr serve \
+  --port 8765 \
+  --api-key mykey123 \
+  --model Qwen/Qwen3-ASR-1.7B \
+  --rate-limit 30 \
+  --max-file-size 500 \
+  --job-ttl 3600 \
+  --host 0.0.0.0
+
+# API key via environment variable
+export MLX_ASR_API_KEY=mykey123
+mlx-qwen3-asr serve
+```
+
+## Client examples
+
+### cURL — file upload
+
+```bash
+curl -X POST http://localhost:8765/transcribe \
+  -H "Authorization: Bearer mykey123" \
+  -F "audio=@meeting.wav" \
+  -F "language=en"
+# → {"job_id": "j_a1b2c3d4", "status": "queued", ...}
+
+curl http://localhost:8765/transcribe/jobs/j_a1b2c3d4 \
+  -H "Authorization: Bearer mykey123"
+# → {"job_id": "j_a1b2c3d4", "status": "completed", "result": {...}}
+```
+
+### cURL — URL reference
+
+```bash
+curl -X POST http://localhost:8765/transcribe \
+  -H "Authorization: Bearer mykey123" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://storage.example.com/clip.wav"}'
+```
+
+### Python
+
+```python
+import requests
+
+API = "http://192.168.1.42:8765"
+KEY = "mykey123"
+headers = {"Authorization": f"Bearer {KEY}"}
+
+# Submit
+with open("meeting.wav", "rb") as f:
+    r = requests.post(f"{API}/transcribe", headers=headers, files={"audio": f})
+job_id = r.json()["job_id"]
+
+# Poll
+import time
+while True:
+    r = requests.get(f"{API}/jobs/{job_id}", headers=headers)
+    data = r.json()
+    if data["status"] in ("completed", "failed"):
+        break
+    time.sleep(1)
+
+print(data["result"]["text"])
+```
+
+## Configuration defaults
+
+| Parameter | Default | CLI flag | Env var |
+|-----------|---------|----------|---------|
+| Port | `8765` | `--port` | `MLX_ASR_PORT` |
+| Host | `0.0.0.0` | `--host` | `MLX_ASR_HOST` |
+| API key(s) | — (required) | `--api-key` | `MLX_ASR_API_KEY` |
+| Model | `Qwen/Qwen3-ASR-0.6B` | `--model` | — |
+| Rate limit | `60` req/min | `--rate-limit` | — |
+| Max file size | `500` MB | `--max-file-size` | — |
+| Job TTL | `3600` seconds | `--job-ttl` | — |
+
+## Future (not in v1)
+
+- WebSocket streaming for real-time audio
+- Callback/webhook on job completion
+- Batch endpoint (multiple files in one request)
+- TLS termination (use reverse proxy for now)
+- Persistent job store (SQLite)

--- a/docs/server/API-SPEC.md
+++ b/docs/server/API-SPEC.md
@@ -1,6 +1,6 @@
 # Transcription Server — API Specification
 
-**Version:** 1.0 (draft)
+**Version:** 1.0 (draft, revised)
 **Date:** 2026-03-20
 
 ## Overview
@@ -9,6 +9,12 @@ HTTP JSON API served by `mlx-qwen3-asr serve`. Turns any Apple Silicon Mac into
 a speech-to-text endpoint.
 
 **Base URL:** `http://<host>:<port>` (default port: `8765`)
+
+## Prerequisites
+
+- Apple Silicon Mac with `pip install mlx-qwen3-asr[serve]`
+- `ffmpeg` installed on the host (`brew install ffmpeg`) — required for non-WAV
+  audio formats (mp3, flac, m4a, ogg, etc.). WAV files work without ffmpeg.
 
 ## Authentication
 
@@ -20,17 +26,25 @@ Authorization: Bearer <api-key>
 
 API keys are configured at server startup via `--api-key` flag or
 `MLX_ASR_API_KEY` environment variable. Multiple keys can be specified
-(comma-separated).
+(comma-separated). **The server refuses to start without at least one key.**
 
 Unauthenticated requests receive `401 Unauthorized`.
 Invalid keys receive `403 Forbidden`.
 
 ## Rate Limiting
 
-Per-key rate limiting. Default: 60 requests/minute. Configurable via
-`--rate-limit`.
+Per-key rate limiting on submission endpoints. Default: 60 requests/minute.
+Configurable via `--rate-limit`.
+
+`GET /jobs/{id}` polling does **not** count against the rate limit, so clients
+can poll freely without burning their submission budget.
 
 Exceeded limits return `429 Too Many Requests` with `Retry-After` header.
+
+## Backpressure
+
+The job queue has a configurable max depth (default: 10). When the queue is full,
+`POST /transcribe` returns `503 Service Unavailable` with a `Retry-After` header.
 
 ---
 
@@ -48,7 +62,8 @@ Health check. No auth required.
   "model": "Qwen/Qwen3-ASR-0.6B",
   "dtype": "float16",
   "uptime_seconds": 3421,
-  "active_jobs": 2
+  "queued_jobs": 2,
+  "max_queue_depth": 10
 }
 ```
 
@@ -58,27 +73,14 @@ Health check. No auth required.
 
 Submit a transcription job. Returns immediately with a job ID.
 
-**Content-Type:** `multipart/form-data` or `application/json`
-
-#### Option A: File upload (multipart)
+**Content-Type:** `multipart/form-data`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `audio` | file | yes | Audio file (wav, mp3, flac, m4a, ogg, etc.) |
-| `language` | string | no | ISO 639-1 language code (e.g., `en`, `ja`). Auto-detect if omitted. |
-| `timestamps` | bool | no | Include word-level timestamps. Default: `false`. |
+| `language` | string | no | Language code (e.g., `en`, `ja`, `zh`). Auto-detect if omitted. |
+| `timestamps` | string | no | `"true"` to include word-level timestamps. Default: `"false"`. Note: timestamps require the forced aligner model (~1.2 GB additional download on first use, ~1.5 GB additional RAM). |
 | `context` | string | no | Custom system prompt for domain vocabulary biasing. |
-
-#### Option B: URL reference (JSON)
-
-```json
-{
-  "url": "https://storage.example.com/meeting.wav",
-  "language": "en",
-  "timestamps": true,
-  "context": ""
-}
-```
 
 **Response** `202 Accepted`:
 
@@ -94,17 +96,29 @@ Submit a transcription job. Returns immediately with a job ID.
 
 | Code | Condition |
 |------|-----------|
-| `400` | No audio provided, unsupported format, or file exceeds size limit |
+| `400` | No audio file provided, or unsupported format |
 | `401` | Missing auth token |
 | `403` | Invalid auth token |
+| `413` | File too large (default max: 200 MB) |
+| `422` | Audio duration exceeds max allowed (default: 30 minutes) |
 | `429` | Rate limit exceeded |
-| `413` | File too large (default max: 500 MB) |
+| `503` | Queue full — server is at capacity |
 
 ---
 
 ### `GET /jobs/{job_id}`
 
-Poll job status and retrieve results.
+Poll job status and retrieve results. Does not count against rate limit.
+
+**Response** `200 OK` (queued):
+
+```json
+{
+  "job_id": "j_a1b2c3d4",
+  "status": "queued",
+  "created_at": "2026-03-20T14:30:00Z"
+}
+```
 
 **Response** `200 OK` (processing):
 
@@ -112,8 +126,7 @@ Poll job status and retrieve results.
 {
   "job_id": "j_a1b2c3d4",
   "status": "processing",
-  "created_at": "2026-03-20T14:30:00Z",
-  "progress": null
+  "created_at": "2026-03-20T14:30:00Z"
 }
 ```
 
@@ -127,32 +140,45 @@ Poll job status and retrieve results.
   "completed_at": "2026-03-20T14:30:12Z",
   "result": {
     "text": "The full transcription text here.",
-    "language": "en",
-    "duration": 45.2,
+    "language": "English",
     "segments": [
       {
-        "start": 0.0,
-        "end": 3.5,
-        "text": "The full transcription"
-      },
-      {
-        "start": 3.5,
-        "end": 5.1,
-        "text": "text here."
-      }
-    ],
-    "words": [
-      {
-        "word": "The",
+        "text": "The",
         "start": 0.0,
         "end": 0.3
+      },
+      {
+        "text": "full",
+        "start": 0.3,
+        "end": 0.6
+      }
+    ],
+    "chunks": [
+      {
+        "text": "The full transcription text here.",
+        "start": 0.0,
+        "end": 5.1,
+        "chunk_index": 0,
+        "language": "English"
       }
     ]
   }
 }
 ```
 
-`words` array is only present when `timestamps: true` was requested.
+**Response schema notes:**
+
+The `result` object directly mirrors the library's `TranscriptionResult` dataclass:
+
+| Field | Type | Always present | Description |
+|-------|------|---------------|-------------|
+| `text` | string | yes | Full transcription text |
+| `language` | string | yes | Detected or forced language. Returns the library's canonical form (e.g., `"English"`, `"Japanese"`), not ISO codes. |
+| `segments` | array | only with `timestamps: true` | Word-level timestamps from forced aligner. Each item: `{text, start, end}`. |
+| `chunks` | array | only for chunked audio | Chunk-level transcripts for long audio. Each item: `{text, start, end, chunk_index, language}`. |
+| `speaker_segments` | array | only with diarization | Speaker-attributed spans (future). Each item: `{speaker, start, end, text}`. |
+
+The server passes through the library output as-is — no schema translation layer.
 
 **Response** `200 OK` (failed):
 
@@ -173,14 +199,6 @@ Poll job status and retrieve results.
 
 ---
 
-### `DELETE /jobs/{job_id}`
-
-Delete a job and its results. Useful for cleanup.
-
-**Response** `204 No Content`
-
----
-
 ## Job lifecycle
 
 ```
@@ -188,10 +206,32 @@ queued → processing → completed
                     → failed
 ```
 
-- Jobs are stored in-memory. Default TTL: 1 hour after completion.
+- Jobs are stored in-memory. Default TTL: 1 hour after completion/failure.
 - Server restart clears all jobs.
 - Only one job processes at a time (sequential model inference). Queued jobs
   wait in FIFO order.
+- Max queue depth: 10 (configurable). Submissions beyond this return `503`.
+
+## Temp file lifecycle
+
+Uploaded audio is written to a `tempfile.NamedTemporaryFile` on disk (system
+temp directory). The file is deleted in a `finally` block after transcription
+completes or fails. Temp files for expired jobs are also cleaned up during
+TTL expiry sweeps.
+
+## CLI subcommand
+
+The `serve` subcommand requires converting the existing CLI to a subcommand
+architecture. The current CLI treats the first positional arg as an audio file
+path. After the change:
+
+```
+mlx-qwen3-asr transcribe audio.wav    # explicit transcribe subcommand
+mlx-qwen3-asr audio.wav               # legacy shorthand (positional arg without subcommand)
+mlx-qwen3-asr serve [options]         # start server
+```
+
+Backward compatibility: bare `mlx-qwen3-asr audio.wav` continues to work.
 
 ## CLI usage
 
@@ -205,7 +245,9 @@ mlx-qwen3-asr serve \
   --api-key mykey123 \
   --model Qwen/Qwen3-ASR-1.7B \
   --rate-limit 30 \
-  --max-file-size 500 \
+  --max-file-size 200 \
+  --max-duration 1800 \
+  --max-queue-depth 10 \
   --job-ttl 3600 \
   --host 0.0.0.0
 
@@ -216,33 +258,27 @@ mlx-qwen3-asr serve
 
 ## Client examples
 
-### cURL — file upload
+### cURL
 
 ```bash
+# Submit
 curl -X POST http://localhost:8765/transcribe \
   -H "Authorization: Bearer mykey123" \
   -F "audio=@meeting.wav" \
   -F "language=en"
 # → {"job_id": "j_a1b2c3d4", "status": "queued", ...}
 
-curl http://localhost:8765/transcribe/jobs/j_a1b2c3d4 \
+# Poll
+curl http://localhost:8765/jobs/j_a1b2c3d4 \
   -H "Authorization: Bearer mykey123"
 # → {"job_id": "j_a1b2c3d4", "status": "completed", "result": {...}}
-```
-
-### cURL — URL reference
-
-```bash
-curl -X POST http://localhost:8765/transcribe \
-  -H "Authorization: Bearer mykey123" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://storage.example.com/clip.wav"}'
 ```
 
 ### Python
 
 ```python
 import requests
+import time
 
 API = "http://192.168.1.42:8765"
 KEY = "mykey123"
@@ -254,7 +290,6 @@ with open("meeting.wav", "rb") as f:
 job_id = r.json()["job_id"]
 
 # Poll
-import time
 while True:
     r = requests.get(f"{API}/jobs/{job_id}", headers=headers)
     data = r.json()
@@ -274,12 +309,16 @@ print(data["result"]["text"])
 | API key(s) | — (required) | `--api-key` | `MLX_ASR_API_KEY` |
 | Model | `Qwen/Qwen3-ASR-0.6B` | `--model` | — |
 | Rate limit | `60` req/min | `--rate-limit` | — |
-| Max file size | `500` MB | `--max-file-size` | — |
+| Max file size | `200` MB | `--max-file-size` | — |
+| Max audio duration | `1800` seconds (30 min) | `--max-duration` | — |
+| Max queue depth | `10` | `--max-queue-depth` | — |
 | Job TTL | `3600` seconds | `--job-ttl` | — |
 
 ## Future (not in v1)
 
+- URL ingestion (requires SSRF mitigation: scheme allowlist, private-IP blocking, redirect limits)
 - WebSocket streaming for real-time audio
+- Job cancellation and `DELETE /jobs/{id}`
 - Callback/webhook on job completion
 - Batch endpoint (multiple files in one request)
 - TLS termination (use reverse proxy for now)

--- a/docs/server/API-SPEC.md
+++ b/docs/server/API-SPEC.md
@@ -63,6 +63,7 @@ Health check. No auth required.
   "dtype": "float16",
   "uptime_seconds": 3421,
   "queued_jobs": 2,
+  "processing_jobs": 1,
   "max_queue_depth": 10
 }
 ```

--- a/docs/server/DEPLOYMENT.md
+++ b/docs/server/DEPLOYMENT.md
@@ -1,0 +1,150 @@
+# Deployment Guide
+
+How to run `mlx-qwen3-asr serve` as an internet-facing transcription server.
+
+## Quick start (LAN)
+
+```bash
+pip install mlx-qwen3-asr[serve]
+mlx-qwen3-asr serve --api-key $(openssl rand -hex 16)
+```
+
+Your Mac is now a transcription server on your local network.
+
+## Internet-facing deployment
+
+For internet exposure, put the server behind a reverse proxy that handles TLS
+and connection management. The ASR server itself is HTTP-only by design.
+
+### Architecture
+
+```
+Internet → Reverse Proxy (TLS) → mlx-qwen3-asr serve (localhost:8765)
+           (nginx / caddy)
+```
+
+### Option A: Caddy (simplest)
+
+```
+# /etc/caddy/Caddyfile
+transcribe.yourdomain.com {
+    reverse_proxy localhost:8765
+}
+```
+
+Caddy handles TLS certificates automatically via Let's Encrypt.
+
+### Option B: nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name transcribe.yourdomain.com;
+
+    ssl_certificate     /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    client_max_body_size 500M;
+
+    location / {
+        proxy_pass http://127.0.0.1:8765;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Option C: Tailscale / Cloudflare Tunnel
+
+For private internet access without opening ports:
+
+```bash
+# Tailscale (machine-to-machine VPN)
+tailscale serve --bg 8765
+
+# Cloudflare Tunnel
+cloudflared tunnel --url http://localhost:8765
+```
+
+Both options handle TLS and avoid exposing your Mac's IP directly.
+
+## Running as a system service
+
+### launchd (macOS native)
+
+Create `~/Library/LaunchAgents/com.mlx-qwen3-asr.serve.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mlx-qwen3-asr.serve</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/venv/bin/mlx-qwen3-asr</string>
+        <string>serve</string>
+        <string>--port</string>
+        <string>8765</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>MLX_ASR_API_KEY</key>
+        <string>your-api-key-here</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/mlx-qwen3-asr.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/mlx-qwen3-asr.err</string>
+</dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.mlx-qwen3-asr.serve.plist
+```
+
+## Operational notes
+
+### Model pre-download
+
+First run downloads the model from HuggingFace (~1.2 GB for 0.6B, ~3.4 GB for
+1.7B). Pre-download to avoid startup delay:
+
+```bash
+python -c "from mlx_qwen3_asr import load_model; load_model()"
+```
+
+### Memory usage
+
+| Model | Approximate RAM |
+|-------|----------------|
+| 0.6B fp16 | ~1.5 GB |
+| 0.6B 4-bit | ~0.5 GB |
+| 1.7B fp16 | ~3.5 GB |
+| 1.7B 4-bit | ~1.2 GB |
+
+Plus overhead for audio processing and job state. A Mac Mini with 16 GB RAM
+handles the 0.6B model comfortably with room for the OS and other processes.
+
+### Monitoring
+
+- `GET /health` — check server status, model info, active job count
+- Log output goes to stdout/stderr (capture via launchd or redirect)
+- Watch for OOM: if the Mac starts swapping, the model is too large for
+  available memory
+
+### Security checklist
+
+- [ ] TLS via reverse proxy (never expose HTTP to the internet)
+- [ ] Strong API key (at least 32 hex characters)
+- [ ] File size limit configured appropriately
+- [ ] Rate limit configured appropriately
+- [ ] Firewall rules if not using tunnel

--- a/docs/server/DEPLOYMENT.md
+++ b/docs/server/DEPLOYMENT.md
@@ -2,6 +2,13 @@
 
 How to run `mlx-qwen3-asr serve` as an internet-facing transcription server.
 
+## Prerequisites
+
+- Apple Silicon Mac (M1 or later)
+- Python 3.10+
+- `ffmpeg` installed (`brew install ffmpeg`) — required for non-WAV audio formats.
+  WAV uploads work without ffmpeg.
+
 ## Quick start (LAN)
 
 ```bash
@@ -44,7 +51,7 @@ server {
     ssl_certificate     /path/to/cert.pem;
     ssl_certificate_key /path/to/key.pem;
 
-    client_max_body_size 500M;
+    client_max_body_size 200M;
 
     location / {
         proxy_pass http://127.0.0.1:8765;
@@ -124,27 +131,32 @@ python -c "from mlx_qwen3_asr import load_model; load_model()"
 
 ### Memory usage
 
-| Model | Approximate RAM |
-|-------|----------------|
-| 0.6B fp16 | ~1.5 GB |
-| 0.6B 4-bit | ~0.5 GB |
-| 1.7B fp16 | ~3.5 GB |
-| 1.7B 4-bit | ~1.2 GB |
+| Model | ASR model RAM | + Forced aligner | Total |
+|-------|--------------|-----------------|-------|
+| 0.6B fp16 | ~1.5 GB | +~1.5 GB | ~3 GB |
+| 0.6B 4-bit | ~0.5 GB | +~1.5 GB | ~2 GB |
+| 1.7B fp16 | ~3.5 GB | +~1.5 GB | ~5 GB |
+| 1.7B 4-bit | ~1.2 GB | +~1.5 GB | ~2.7 GB |
 
-Plus overhead for audio processing and job state. A Mac Mini with 16 GB RAM
-handles the 0.6B model comfortably with room for the OS and other processes.
+Forced aligner is only loaded when `timestamps: true` is requested (lazy load
+on first timestamped request, stays in memory after that).
+
+Plus overhead for audio processing, temp files, and job state. A Mac Mini with
+16 GB RAM handles the 0.6B model comfortably with room for the OS and other
+processes.
 
 ### Monitoring
 
-- `GET /health` — check server status, model info, active job count
+- `GET /health` — check server status, model info, queue depth
 - Log output goes to stdout/stderr (capture via launchd or redirect)
 - Watch for OOM: if the Mac starts swapping, the model is too large for
   available memory
 
 ### Security checklist
 
-- [ ] TLS via reverse proxy (never expose HTTP to the internet)
-- [ ] Strong API key (at least 32 hex characters)
-- [ ] File size limit configured appropriately
-- [ ] Rate limit configured appropriately
+- [ ] TLS via reverse proxy (never expose HTTP directly to the internet)
+- [ ] Strong API key (at least 32 hex characters: `openssl rand -hex 16`)
+- [ ] File size limit configured appropriately (`--max-file-size`)
+- [ ] Max audio duration configured (`--max-duration`)
+- [ ] Rate limit configured appropriately (`--rate-limit`)
 - [ ] Firewall rules if not using tunnel

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -26,28 +26,23 @@ GET /jobs/{id}    ─────────→  Return result
                           (Metal GPU)
 ```
 
+Jobs process sequentially (one at a time, FIFO). Queue capped at 10 by default;
+returns `503` when full.
+
 ## API at a glance
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/health` | GET | Server status (no auth) |
-| `/transcribe` | POST | Submit audio for transcription |
-| `/jobs/{id}` | GET | Poll job status / get result |
-| `/jobs/{id}` | DELETE | Delete a job |
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/health` | GET | No | Server status, queue depth |
+| `/transcribe` | POST | Yes | Submit audio file for transcription |
+| `/jobs/{id}` | GET | Yes | Poll job status / get result |
 
 ### Submit audio
 
 ```bash
-# File upload
 curl -X POST http://localhost:8765/transcribe \
   -H "Authorization: Bearer YOUR_KEY" \
   -F "audio=@recording.wav"
-
-# URL reference
-curl -X POST http://localhost:8765/transcribe \
-  -H "Authorization: Bearer YOUR_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://storage.example.com/audio.wav"}'
 ```
 
 ### Get result
@@ -63,11 +58,14 @@ curl http://localhost:8765/jobs/j_a1b2c3d4 \
   "status": "completed",
   "result": {
     "text": "Your transcribed text here.",
-    "language": "en",
-    "duration": 12.5
+    "language": "English"
   }
 }
 ```
+
+The `result` object mirrors the library's `TranscriptionResult` directly —
+includes `segments` (word timestamps) and `chunks` (long-audio chunks) when
+applicable.
 
 ## Configuration
 
@@ -77,11 +75,18 @@ curl http://localhost:8765/jobs/j_a1b2c3d4 \
 | `--host` | `0.0.0.0` | Bind address |
 | `--api-key` | — (required) | API key(s), comma-separated |
 | `--model` | `Qwen/Qwen3-ASR-0.6B` | Model to load |
-| `--rate-limit` | `60` | Max requests per minute per key |
-| `--max-file-size` | `500` | Max upload size in MB |
+| `--rate-limit` | `60` | Max submissions per minute per key |
+| `--max-file-size` | `200` | Max upload size in MB |
+| `--max-duration` | `1800` | Max audio duration in seconds |
+| `--max-queue-depth` | `10` | Max queued jobs before 503 |
 | `--job-ttl` | `3600` | Seconds to keep completed jobs |
 
 API key can also be set via `MLX_ASR_API_KEY` environment variable.
+
+## Prerequisites
+
+- Apple Silicon Mac (M1+)
+- `ffmpeg` for non-WAV formats (`brew install ffmpeg`). WAV uploads work without it.
 
 ## Internet-facing deployment
 
@@ -102,12 +107,12 @@ tailscale serve --bg 8765
 ```
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for full deployment guide including launchd
-service configuration.
+service configuration and security checklist.
 
 ## Documentation
 
 | Document | Contents |
 |----------|----------|
-| [API-SPEC.md](API-SPEC.md) | Full API specification — endpoints, schemas, auth, rate limiting |
-| [ADR-001-transcription-server.md](ADR-001-transcription-server.md) | Architecture decision record — design choices and rationale |
-| [DEPLOYMENT.md](DEPLOYMENT.md) | Deployment guide — reverse proxy, launchd, security checklist |
+| [API-SPEC.md](API-SPEC.md) | Full API specification — endpoints, schemas, auth, rate limiting, backpressure |
+| [ADR-001-transcription-server.md](ADR-001-transcription-server.md) | Architecture decision record — design choices, rationale, alternatives rejected |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Deployment guide — reverse proxy, launchd, memory sizing, security checklist |

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -34,8 +34,9 @@ returns `503` when full.
 | Endpoint | Method | Auth | Description |
 |----------|--------|------|-------------|
 | `/health` | GET | No | Server status, queue depth |
-| `/transcribe` | POST | Yes | Submit audio file for transcription |
+| `/transcribe` | POST | Yes | Submit audio → async job (poll for result) |
 | `/jobs/{id}` | GET | Yes | Poll job status / get result |
+| `/v1/audio/transcriptions` | POST | Yes | OpenAI-compatible (synchronous) |
 
 ### Submit audio
 
@@ -66,6 +67,25 @@ curl http://localhost:8765/jobs/j_a1b2c3d4 \
 The `result` object mirrors the library's `TranscriptionResult` directly —
 includes `segments` (word timestamps) and `chunks` (long-audio chunks) when
 applicable.
+
+### OpenAI-compatible endpoint
+
+Existing OpenAI SDK code works with zero changes — just point at your Mac:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="YOUR_KEY", base_url="http://localhost:8765/v1")
+result = client.audio.transcriptions.create(
+    model="Qwen/Qwen3-ASR-0.6B",
+    file=open("recording.wav", "rb"),
+)
+print(result.text)
+```
+
+Supports `response_format`: `json`, `text`, `verbose_json`, `srt`, `vtt`.
+This endpoint is synchronous (blocks until done) — for long audio, use the
+async `/transcribe` + polling flow instead.
 
 ## Configuration
 

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,0 +1,113 @@
+# Transcription Server
+
+Turn any Apple Silicon Mac into a speech-to-text API endpoint.
+
+```bash
+pip install mlx-qwen3-asr[serve]
+mlx-qwen3-asr serve --api-key $(openssl rand -hex 16)
+```
+
+That's it. Your Mac is now a transcription server.
+
+## How it works
+
+The server wraps the `mlx-qwen3-asr` library in a FastAPI HTTP service. Audio
+goes in, text comes out. The Qwen3-ASR model stays loaded in memory across
+requests — no per-request startup cost.
+
+```
+Client (any device)           Mac (server)
+─────────────────            ──────────────
+POST /transcribe  ─────────→  Queue job
+                               │
+GET /jobs/{id}    ─────────→  Return result
+                               ↑
+                          MLX inference
+                          (Metal GPU)
+```
+
+## API at a glance
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Server status (no auth) |
+| `/transcribe` | POST | Submit audio for transcription |
+| `/jobs/{id}` | GET | Poll job status / get result |
+| `/jobs/{id}` | DELETE | Delete a job |
+
+### Submit audio
+
+```bash
+# File upload
+curl -X POST http://localhost:8765/transcribe \
+  -H "Authorization: Bearer YOUR_KEY" \
+  -F "audio=@recording.wav"
+
+# URL reference
+curl -X POST http://localhost:8765/transcribe \
+  -H "Authorization: Bearer YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://storage.example.com/audio.wav"}'
+```
+
+### Get result
+
+```bash
+curl http://localhost:8765/jobs/j_a1b2c3d4 \
+  -H "Authorization: Bearer YOUR_KEY"
+```
+
+```json
+{
+  "job_id": "j_a1b2c3d4",
+  "status": "completed",
+  "result": {
+    "text": "Your transcribed text here.",
+    "language": "en",
+    "duration": 12.5
+  }
+}
+```
+
+## Configuration
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | `8765` | Server port |
+| `--host` | `0.0.0.0` | Bind address |
+| `--api-key` | — (required) | API key(s), comma-separated |
+| `--model` | `Qwen/Qwen3-ASR-0.6B` | Model to load |
+| `--rate-limit` | `60` | Max requests per minute per key |
+| `--max-file-size` | `500` | Max upload size in MB |
+| `--job-ttl` | `3600` | Seconds to keep completed jobs |
+
+API key can also be set via `MLX_ASR_API_KEY` environment variable.
+
+## Internet-facing deployment
+
+For internet exposure, put the server behind a reverse proxy for TLS:
+
+```
+Internet → Caddy/nginx (TLS) → mlx-qwen3-asr serve (localhost:8765)
+```
+
+Or use a tunnel:
+
+```bash
+# Cloudflare Tunnel
+cloudflared tunnel --url http://localhost:8765
+
+# Tailscale
+tailscale serve --bg 8765
+```
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for full deployment guide including launchd
+service configuration.
+
+## Documentation
+
+| Document | Contents |
+|----------|----------|
+| [API-SPEC.md](API-SPEC.md) | Full API specification — endpoints, schemas, auth, rate limiting |
+| [ADR-001-transcription-server.md](ADR-001-transcription-server.md) | Architecture decision record — design choices and rationale |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Deployment guide — reverse proxy, launchd, security checklist |

--- a/mlx_qwen3_asr/cli.py
+++ b/mlx_qwen3_asr/cli.py
@@ -266,8 +266,81 @@ def _emit_new_stable_text(
     return current
 
 
+def _parse_serve_args(argv: list[str]) -> None:
+    """Parse and run the ``serve`` subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="mlx-qwen3-asr serve",
+        description="Start the transcription HTTP server",
+    )
+    parser.add_argument(
+        "--host", default=os.environ.get("MLX_ASR_HOST", "0.0.0.0"),
+        help="Bind address (default: 0.0.0.0, env: MLX_ASR_HOST)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=int(os.environ.get("MLX_ASR_PORT", "8765")),
+        help="Server port (default: 8765, env: MLX_ASR_PORT)",
+    )
+    parser.add_argument(
+        "--api-key", default=os.environ.get("MLX_ASR_API_KEY", ""),
+        help="API key(s), comma-separated (env: MLX_ASR_API_KEY)",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL_ID,
+        help=f"Model name or path (default: {DEFAULT_MODEL_ID})",
+    )
+    parser.add_argument(
+        "--dtype", default="float16",
+        choices=["float16", "float32", "bfloat16"],
+        help="Model dtype (default: float16)",
+    )
+    parser.add_argument(
+        "--rate-limit", type=int, default=60,
+        help="Max submissions per minute per key (default: 60)",
+    )
+    parser.add_argument(
+        "--max-file-size", type=int, default=200,
+        help="Max upload size in MB (default: 200)",
+    )
+    parser.add_argument(
+        "--max-duration", type=int, default=1800,
+        help="Max audio duration in seconds (default: 1800)",
+    )
+    parser.add_argument(
+        "--max-queue-depth", type=int, default=10,
+        help="Max queued jobs before 503 (default: 10)",
+    )
+    parser.add_argument(
+        "--job-ttl", type=int, default=3600,
+        help="Seconds to keep completed jobs (default: 3600)",
+    )
+    args = parser.parse_args(argv)
+
+    api_keys = [k.strip() for k in args.api_key.split(",") if k.strip()]
+
+    from .server import ServerConfig, run_server
+
+    config = ServerConfig(
+        host=args.host,
+        port=args.port,
+        api_keys=api_keys,
+        model=args.model,
+        dtype=args.dtype,
+        rate_limit=args.rate_limit,
+        max_file_size_mb=args.max_file_size,
+        max_duration_sec=args.max_duration,
+        max_queue_depth=args.max_queue_depth,
+        job_ttl_sec=args.job_ttl,
+    )
+    run_server(config)
+
+
 def main():
     """CLI entry point for mlx-qwen3-asr."""
+    # Intercept "serve" subcommand before main parser
+    if len(sys.argv) > 1 and sys.argv[1] == "serve":
+        _parse_serve_args(sys.argv[2:])
+        return
+
     parser = argparse.ArgumentParser(
         prog="mlx-qwen3-asr",
         description="Qwen3-ASR speech recognition on Apple Silicon via MLX",

--- a/mlx_qwen3_asr/server.py
+++ b/mlx_qwen3_asr/server.py
@@ -41,6 +41,7 @@ class Job:
     job_id: str
     status: JobStatus
     created_at: float
+    api_key: str = ""
     completed_at: Optional[float] = None
     result: Optional[dict] = None
     error: Optional[str] = None
@@ -183,13 +184,13 @@ def create_app(config: ServerConfig):
                 logger.exception("Job %s failed", job_id)
                 job.status = JobStatus.FAILED
                 job.completed_at = time.time()
-                job.error = str(exc)
+                job.error = _sanitize_error(exc)
             finally:
                 _cleanup_temp(job)
                 state.job_queue.task_done()
 
     async def _run_transcription(job: Job) -> dict:
-        """Run transcription in a thread to avoid blocking the event loop."""
+        """Run transcription via Session.transcribe_async (thread offload)."""
         session = state.session
         result = await session.transcribe_async(
             job.temp_path,
@@ -242,6 +243,12 @@ def create_app(config: ServerConfig):
 
         worker_task.cancel()
         sweeper_task.cancel()
+        # Await cancellation to ensure cleanup runs
+        for task in (worker_task, sweeper_task):
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     app = FastAPI(
         title="mlx-qwen3-asr",
@@ -265,7 +272,8 @@ def create_app(config: ServerConfig):
             "model": config.model,
             "dtype": config.dtype,
             "uptime_seconds": round(time.monotonic() - state.start_time),
-            "queued_jobs": queued + processing,
+            "queued_jobs": queued,
+            "processing_jobs": processing,
             "max_queue_depth": config.max_queue_depth,
         }
 
@@ -286,14 +294,6 @@ def create_app(config: ServerConfig):
                 status_code=429,
                 detail="Rate limit exceeded",
                 headers={"Retry-After": str(int(retry) + 1)},
-            )
-
-        # Backpressure
-        if state.job_queue.full():
-            raise HTTPException(
-                status_code=503,
-                detail="Server at capacity",
-                headers={"Retry-After": "10"},
             )
 
         # File size check
@@ -323,11 +323,12 @@ def create_app(config: ServerConfig):
             raise
 
         # Create job
-        job_id = f"j_{uuid.uuid4().hex[:8]}"
+        job_id = f"j_{uuid.uuid4().hex}"
         job = Job(
             job_id=job_id,
             status=JobStatus.QUEUED,
             created_at=time.time(),
+            api_key=key,
             temp_path=tmp.name,
             language=language,
             timestamps=_parse_bool(timestamps),
@@ -335,8 +336,18 @@ def create_app(config: ServerConfig):
         )
         state.jobs[job_id] = job
 
-        # Enqueue
-        await state.job_queue.put(job_id)
+        # Atomic enqueue with backpressure
+        try:
+            state.job_queue.put_nowait(job_id)
+        except asyncio.QueueFull:
+            # Clean up the job and temp file we just created
+            state.jobs.pop(job_id, None)
+            _cleanup_temp(job)
+            raise HTTPException(
+                status_code=503,
+                detail="Server at capacity",
+                headers={"Retry-After": "10"},
+            )
 
         return {
             "job_id": job_id,
@@ -346,11 +357,15 @@ def create_app(config: ServerConfig):
 
     @app.get("/jobs/{job_id}")
     async def get_job(request: Request, job_id: str) -> dict:
-        _check_auth(request)
+        key = _check_auth(request)
         # Polling does NOT count against rate limit
 
         job = state.jobs.get(job_id)
         if job is None:
+            raise HTTPException(status_code=404, detail="Job not found")
+
+        # Enforce job ownership — only the submitting key can read the job
+        if job.api_key and job.api_key != key:
             raise HTTPException(status_code=404, detail="Job not found")
 
         resp: dict = {
@@ -402,7 +417,19 @@ def _format_time(ts: Optional[float]) -> Optional[str]:
         return None
     from datetime import datetime, timezone
 
-    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sanitize_error(exc: Exception) -> str:
+    """Return a safe error message without leaking internal paths."""
+    msg = str(exc)
+    # Strip common path prefixes that leak server internals
+    for prefix in ("/tmp/", "/var/", "/Users/", "/home/"):
+        if prefix in msg:
+            msg = type(exc).__name__ + ": transcription failed"
+            break
+    return msg
 
 
 def _cleanup_temp(job: Job) -> None:
@@ -415,6 +442,27 @@ def _cleanup_temp(job: Job) -> None:
 # Entry point (called from CLI)
 # ---------------------------------------------------------------------------
 
+def _validate_config(config: ServerConfig) -> None:
+    """Validate server config at startup. Raises SystemExit on invalid values."""
+    errors: list[str] = []
+    if not config.api_keys:
+        errors.append("at least one API key is required (--api-key or MLX_ASR_API_KEY)")
+    if config.rate_limit < 1:
+        errors.append("--rate-limit must be >= 1")
+    if config.max_queue_depth < 1:
+        errors.append("--max-queue-depth must be >= 1")
+    if config.max_file_size_mb < 1:
+        errors.append("--max-file-size must be >= 1")
+    if config.max_duration_sec < 1:
+        errors.append("--max-duration must be >= 1")
+    if config.job_ttl_sec < 1:
+        errors.append("--job-ttl must be >= 1")
+    if config.port < 1 or config.port > 65535:
+        errors.append("--port must be between 1 and 65535")
+    if errors:
+        raise SystemExit("Error: " + "; ".join(errors))
+
+
 def run_server(config: ServerConfig) -> None:
     """Start the server with uvicorn."""
     try:
@@ -425,10 +473,7 @@ def run_server(config: ServerConfig) -> None:
             'Install with: pip install "mlx-qwen3-asr[serve]"'
         ) from exc
 
-    if not config.api_keys:
-        raise SystemExit(
-            "Error: at least one API key is required (--api-key or MLX_ASR_API_KEY)"
-        )
+    _validate_config(config)
 
     app = create_app(config)
     logger.info(

--- a/mlx_qwen3_asr/server.py
+++ b/mlx_qwen3_asr/server.py
@@ -383,6 +383,92 @@ def create_app(config: ServerConfig):
 
         return resp
 
+    # ---- OpenAI-compatible endpoint ----
+
+    @app.post("/v1/audio/transcriptions")
+    async def openai_transcriptions(
+        request: Request,
+        file: UploadFile = File(...),
+        model: Optional[str] = Form(None),
+        language: Optional[str] = Form(None),
+        prompt: Optional[str] = Form(None),
+        response_format: Optional[str] = Form("json"),
+        temperature: Optional[float] = Form(None),
+    ):
+        """OpenAI-compatible transcription endpoint.
+
+        Synchronous — blocks until transcription completes and returns the
+        result directly.  Accepts the same fields as OpenAI's
+        ``POST /v1/audio/transcriptions``.
+        """
+        key = _check_auth(request)
+
+        # Rate limit
+        if not state.rate_limiter.is_allowed(key):
+            retry = state.rate_limiter.retry_after(key)
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded",
+                headers={"Retry-After": str(int(retry) + 1)},
+            )
+
+        # Validate response_format
+        fmt = (response_format or "json").strip().lower()
+        if fmt not in _OPENAI_FORMATS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid response_format '{response_format}'. "
+                    f"Supported: {', '.join(sorted(_OPENAI_FORMATS))}"
+                ),
+            )
+
+        # File size check
+        contents = await file.read()
+        size_mb = len(contents) / (1024 * 1024)
+        if size_mb > config.max_file_size_mb:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"File too large ({size_mb:.1f} MB). "
+                    f"Max: {config.max_file_size_mb} MB"
+                ),
+            )
+
+        # Write temp file
+        suffix = Path(file.filename or "upload.wav").suffix or ".wav"
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=suffix, delete=False, prefix="mlx_asr_"
+        )
+        try:
+            tmp.write(contents)
+            tmp.flush()
+            tmp.close()
+        except Exception:
+            tmp.close()
+            Path(tmp.name).unlink(missing_ok=True)
+            raise
+
+        # Timestamps needed for verbose_json, srt, vtt
+        need_timestamps = fmt in ("verbose_json", "srt", "vtt")
+
+        # Synchronous transcription — bypasses job queue
+        try:
+            result = await state.session.transcribe_async(
+                tmp.name,
+                language=language,
+                context=prompt or "",
+                return_timestamps=need_timestamps,
+            )
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500, detail=_sanitize_error(exc)
+            )
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+        return _openai_format_response(result, fmt)
+
     return app
 
 
@@ -436,6 +522,106 @@ def _cleanup_temp(job: Job) -> None:
     if job.temp_path:
         Path(job.temp_path).unlink(missing_ok=True)
         job.temp_path = None
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible response formatting
+# ---------------------------------------------------------------------------
+
+_OPENAI_FORMATS = frozenset({"json", "text", "verbose_json", "srt", "vtt"})
+
+
+def _openai_format_response(result: object, fmt: str):
+    """Format a TranscriptionResult as an OpenAI-compatible response."""
+    from fastapi.responses import PlainTextResponse
+
+    from .transcribe import TranscriptionResult
+
+    if not isinstance(result, TranscriptionResult):
+        return {"text": str(result)}
+
+    if fmt == "text":
+        return PlainTextResponse(result.text)
+
+    if fmt == "json":
+        return {"text": result.text}
+
+    if fmt == "verbose_json":
+        resp: dict = {
+            "task": "transcribe",
+            "language": (result.language or "").lower(),
+            "duration": _estimate_duration(result),
+            "text": result.text,
+        }
+        if result.segments:
+            resp["words"] = [
+                {"word": s["text"], "start": s["start"], "end": s["end"]}
+                for s in result.segments
+            ]
+        return resp
+
+    # srt / vtt — need subtitle grouping
+    from .writers import group_subtitle_segments
+
+    if not result.segments:
+        return PlainTextResponse(result.text, media_type="text/plain")
+
+    grouped = group_subtitle_segments(
+        result.segments, language=result.language or ""
+    )
+
+    if fmt == "srt":
+        return PlainTextResponse(_format_srt(grouped), media_type="text/plain")
+
+    return PlainTextResponse(_format_vtt(grouped), media_type="text/plain")
+
+
+def _estimate_duration(result: object) -> float:
+    """Estimate audio duration from transcription result timestamps."""
+    segments = getattr(result, "segments", None)
+    if segments:
+        return max((s.get("end", 0.0) for s in segments), default=0.0)
+    chunks = getattr(result, "chunks", None)
+    if chunks:
+        return max((c.get("end", 0.0) for c in chunks), default=0.0)
+    return 0.0
+
+
+def _format_srt(segments: list[dict]) -> str:
+    """Format grouped subtitle segments as an SRT string."""
+    lines: list[str] = []
+    for i, seg in enumerate(segments, 1):
+        lines.append(str(i))
+        lines.append(f"{_ts_srt(seg['start'])} --> {_ts_srt(seg['end'])}")
+        lines.append(seg["text"])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _format_vtt(segments: list[dict]) -> str:
+    """Format grouped subtitle segments as a WebVTT string."""
+    lines = ["WEBVTT", ""]
+    for seg in segments:
+        lines.append(f"{_ts_vtt(seg['start'])} --> {_ts_vtt(seg['end'])}")
+        lines.append(seg["text"])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _ts_srt(seconds: float) -> str:
+    ms = max(0, int(round(seconds * 1000)))
+    h, ms = divmod(ms, 3_600_000)
+    m, ms = divmod(ms, 60_000)
+    s, ms = divmod(ms, 1000)
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _ts_vtt(seconds: float) -> str:
+    ms = max(0, int(round(seconds * 1000)))
+    h, ms = divmod(ms, 3_600_000)
+    m, ms = divmod(ms, 60_000)
+    s, ms = divmod(ms, 1000)
+    return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
 
 
 # ---------------------------------------------------------------------------

--- a/mlx_qwen3_asr/server.py
+++ b/mlx_qwen3_asr/server.py
@@ -118,6 +118,8 @@ class _AppState:
     api_keys_set: set[str] = field(default_factory=set)
     session: object = None  # Session instance
     config: Optional[ServerConfig] = None
+    inference_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    sync_inflight: int = 0  # count of /v1 requests waiting for inference
 
 
 # ---------------------------------------------------------------------------
@@ -192,13 +194,14 @@ def create_app(config: ServerConfig):
     async def _run_transcription(job: Job) -> dict:
         """Run transcription via Session.transcribe_async (thread offload)."""
         session = state.session
-        result = await session.transcribe_async(
-            job.temp_path,
-            language=job.language,
-            context=job.context,
-            return_timestamps=job.timestamps,
-            return_chunks=True,
-        )
+        async with state.inference_lock:
+            result = await session.transcribe_async(
+                job.temp_path,
+                language=job.language,
+                context=job.context,
+                return_timestamps=job.timestamps,
+                return_chunks=True,
+            )
         return _result_to_dict(result)
 
     async def _ttl_sweeper() -> None:
@@ -452,19 +455,32 @@ def create_app(config: ServerConfig):
         # Timestamps needed for verbose_json, srt, vtt
         need_timestamps = fmt in ("verbose_json", "srt", "vtt")
 
-        # Synchronous transcription — bypasses job queue
-        try:
-            result = await state.session.transcribe_async(
-                tmp.name,
-                language=language,
-                context=prompt or "",
-                return_timestamps=need_timestamps,
+        # Backpressure: count queued jobs + in-flight /v1 requests
+        if state.job_queue.qsize() + state.sync_inflight >= config.max_queue_depth:
+            Path(tmp.name).unlink(missing_ok=True)
+            raise HTTPException(
+                status_code=503,
+                detail="Server at capacity",
+                headers={"Retry-After": "10"},
             )
+
+        # Synchronous transcription — serialized via inference lock
+        state.sync_inflight += 1
+        try:
+            async with state.inference_lock:
+                result = await state.session.transcribe_async(
+                    tmp.name,
+                    language=language,
+                    context=prompt or "",
+                    return_timestamps=need_timestamps,
+                    return_chunks=True,
+                )
         except Exception as exc:
             raise HTTPException(
                 status_code=500, detail=_sanitize_error(exc)
             )
         finally:
+            state.sync_inflight -= 1
             Path(tmp.name).unlink(missing_ok=True)
 
         return _openai_format_response(result, fmt)
@@ -558,13 +574,25 @@ def _openai_format_response(result: object, fmt: str):
                 {"word": s["text"], "start": s["start"], "end": s["end"]}
                 for s in result.segments
             ]
+        if result.chunks:
+            resp["segments"] = [
+                {
+                    "id": c.get("chunk_index", i),
+                    "start": c["start"],
+                    "end": c["end"],
+                    "text": c["text"],
+                }
+                for i, c in enumerate(result.chunks)
+            ]
         return resp
 
     # srt / vtt — need subtitle grouping
     from .writers import group_subtitle_segments
 
     if not result.segments:
-        return PlainTextResponse(result.text, media_type="text/plain")
+        if fmt == "vtt":
+            return PlainTextResponse("WEBVTT\n\n", media_type="text/plain")
+        return PlainTextResponse("", media_type="text/plain")
 
     grouped = group_subtitle_segments(
         result.segments, language=result.language or ""

--- a/mlx_qwen3_asr/server.py
+++ b/mlx_qwen3_asr/server.py
@@ -1,0 +1,438 @@
+"""Built-in HTTP transcription server for mlx-qwen3-asr.
+
+Turns any Apple Silicon Mac into a speech-to-text API endpoint.
+Requires optional dependencies: ``pip install mlx-qwen3-asr[serve]``
+
+Usage::
+
+    mlx-qwen3-asr serve --port 8765 --api-key mykey123
+"""
+
+import asyncio
+import logging
+import tempfile
+import time
+import uuid
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("mlx_qwen3_asr.server")
+
+
+# ---------------------------------------------------------------------------
+# Job model
+# ---------------------------------------------------------------------------
+
+class JobStatus(str, Enum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class Job:
+    """In-memory representation of a transcription job."""
+
+    job_id: str
+    status: JobStatus
+    created_at: float
+    completed_at: Optional[float] = None
+    result: Optional[dict] = None
+    error: Optional[str] = None
+    temp_path: Optional[str] = None
+
+    # Request parameters
+    language: Optional[str] = None
+    timestamps: bool = False
+    context: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Server config
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ServerConfig:
+    """Server configuration populated from CLI flags / env vars."""
+
+    host: str = "0.0.0.0"
+    port: int = 8765
+    api_keys: list[str] = field(default_factory=list)
+    model: str = "Qwen/Qwen3-ASR-0.6B"
+    dtype: str = "float16"
+    rate_limit: int = 60
+    max_file_size_mb: int = 200
+    max_duration_sec: int = 1800
+    max_queue_depth: int = 10
+    job_ttl_sec: int = 3600
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+class _RateLimiter:
+    """Simple sliding-window rate limiter keyed by API key."""
+
+    def __init__(self, max_requests: int, window_sec: float = 60.0) -> None:
+        self._max = max_requests
+        self._window = window_sec
+        self._timestamps: dict[str, list[float]] = defaultdict(list)
+
+    def is_allowed(self, key: str) -> bool:
+        now = time.monotonic()
+        cutoff = now - self._window
+        ts = self._timestamps[key]
+        # Prune expired
+        self._timestamps[key] = [t for t in ts if t > cutoff]
+        if len(self._timestamps[key]) >= self._max:
+            return False
+        self._timestamps[key].append(now)
+        return True
+
+    def retry_after(self, key: str) -> float:
+        ts = self._timestamps.get(key, [])
+        if not ts:
+            return 0.0
+        return max(0.0, ts[0] + self._window - time.monotonic())
+
+
+# ---------------------------------------------------------------------------
+# Shared app state
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _AppState:
+    """Mutable state shared across the application."""
+
+    jobs: dict[str, Job] = field(default_factory=dict)
+    job_queue: Optional[asyncio.Queue] = None
+    rate_limiter: Optional[_RateLimiter] = None
+    start_time: float = 0.0
+    api_keys_set: set[str] = field(default_factory=set)
+    session: object = None  # Session instance
+    config: Optional[ServerConfig] = None
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+def create_app(config: ServerConfig):
+    """Create and return the FastAPI application.
+
+    This factory is the main integration point. It:
+    - Loads the ASR model into a Session on startup
+    - Runs a background worker that processes jobs sequentially
+    - Runs a background sweeper that expires old jobs
+    """
+    try:
+        from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
+    except ImportError as exc:
+        raise ImportError(
+            "Server dependencies not installed. "
+            'Install with: pip install "mlx-qwen3-asr[serve]"'
+        ) from exc
+
+    state = _AppState(
+        job_queue=asyncio.Queue(maxsize=config.max_queue_depth),
+        rate_limiter=_RateLimiter(config.rate_limit),
+        start_time=time.monotonic(),
+        api_keys_set=set(config.api_keys),
+        config=config,
+    )
+
+    # ---- Auth helper ----
+
+    def _check_auth(request: Request) -> str:
+        """Validate Bearer token and return the API key."""
+        auth = request.headers.get("authorization", "")
+        if not auth:
+            raise HTTPException(status_code=401, detail="Missing Authorization header")
+        parts = auth.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            raise HTTPException(status_code=401, detail="Invalid Authorization format")
+        key = parts[1]
+        if key not in state.api_keys_set:
+            raise HTTPException(status_code=403, detail="Invalid API key")
+        return key
+
+    # ---- Background tasks ----
+
+    async def _job_worker() -> None:
+        """Sequential job processor — pulls from queue, runs transcription."""
+        while True:
+            job_id = await state.job_queue.get()
+            job = state.jobs.get(job_id)
+            if job is None or job.status != JobStatus.QUEUED:
+                state.job_queue.task_done()
+                continue
+
+            job.status = JobStatus.PROCESSING
+            try:
+                result = await _run_transcription(job)
+                job.result = result
+                job.status = JobStatus.COMPLETED
+                job.completed_at = time.time()
+            except Exception as exc:
+                logger.exception("Job %s failed", job_id)
+                job.status = JobStatus.FAILED
+                job.completed_at = time.time()
+                job.error = str(exc)
+            finally:
+                _cleanup_temp(job)
+                state.job_queue.task_done()
+
+    async def _run_transcription(job: Job) -> dict:
+        """Run transcription in a thread to avoid blocking the event loop."""
+        session = state.session
+        result = await session.transcribe_async(
+            job.temp_path,
+            language=job.language,
+            context=job.context,
+            return_timestamps=job.timestamps,
+            return_chunks=True,
+        )
+        return _result_to_dict(result)
+
+    async def _ttl_sweeper() -> None:
+        """Periodically remove expired jobs."""
+        while True:
+            await asyncio.sleep(60)
+            now = time.time()
+            expired = [
+                jid
+                for jid, j in state.jobs.items()
+                if j.status in (JobStatus.COMPLETED, JobStatus.FAILED)
+                and j.completed_at is not None
+                and (now - j.completed_at) > config.job_ttl_sec
+            ]
+            for jid in expired:
+                j = state.jobs.pop(jid, None)
+                if j:
+                    _cleanup_temp(j)
+
+    # ---- Lifespan ----
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        logger.info("Loading model %s (dtype=%s)...", config.model, config.dtype)
+        import mlx.core as mx
+
+        from .session import Session
+
+        dtype_map = {
+            "float16": mx.float16,
+            "float32": mx.float32,
+            "bfloat16": mx.bfloat16,
+        }
+        dtype = dtype_map.get(config.dtype, mx.float16)
+        state.session = Session(config.model, dtype=dtype)
+        logger.info("Model loaded: %s", config.model)
+
+        worker_task = asyncio.create_task(_job_worker())
+        sweeper_task = asyncio.create_task(_ttl_sweeper())
+
+        yield
+
+        worker_task.cancel()
+        sweeper_task.cancel()
+
+    app = FastAPI(
+        title="mlx-qwen3-asr",
+        description="Speech-to-text API powered by Qwen3-ASR on Apple Silicon",
+        lifespan=lifespan,
+    )
+
+    # Store state on app for test access
+    app.state.server = state
+
+    # ---- Endpoints ----
+
+    @app.get("/health")
+    async def health() -> dict:
+        queued = sum(1 for j in state.jobs.values() if j.status == JobStatus.QUEUED)
+        processing = sum(
+            1 for j in state.jobs.values() if j.status == JobStatus.PROCESSING
+        )
+        return {
+            "status": "ok",
+            "model": config.model,
+            "dtype": config.dtype,
+            "uptime_seconds": round(time.monotonic() - state.start_time),
+            "queued_jobs": queued + processing,
+            "max_queue_depth": config.max_queue_depth,
+        }
+
+    @app.post("/transcribe", status_code=202)
+    async def transcribe(
+        request: Request,
+        audio: UploadFile = File(...),
+        language: Optional[str] = Form(None),
+        timestamps: Optional[str] = Form(None),
+        context: Optional[str] = Form(None),
+    ) -> dict:
+        key = _check_auth(request)
+
+        # Rate limit (submission only)
+        if not state.rate_limiter.is_allowed(key):
+            retry = state.rate_limiter.retry_after(key)
+            raise HTTPException(
+                status_code=429,
+                detail="Rate limit exceeded",
+                headers={"Retry-After": str(int(retry) + 1)},
+            )
+
+        # Backpressure
+        if state.job_queue.full():
+            raise HTTPException(
+                status_code=503,
+                detail="Server at capacity",
+                headers={"Retry-After": "10"},
+            )
+
+        # File size check
+        contents = await audio.read()
+        size_mb = len(contents) / (1024 * 1024)
+        if size_mb > config.max_file_size_mb:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"File too large ({size_mb:.1f} MB). "
+                    f"Max: {config.max_file_size_mb} MB"
+                ),
+            )
+
+        # Write to temp file
+        suffix = Path(audio.filename or "upload.wav").suffix or ".wav"
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=suffix, delete=False, prefix="mlx_asr_"
+        )
+        try:
+            tmp.write(contents)
+            tmp.flush()
+            tmp.close()
+        except Exception:
+            tmp.close()
+            Path(tmp.name).unlink(missing_ok=True)
+            raise
+
+        # Create job
+        job_id = f"j_{uuid.uuid4().hex[:8]}"
+        job = Job(
+            job_id=job_id,
+            status=JobStatus.QUEUED,
+            created_at=time.time(),
+            temp_path=tmp.name,
+            language=language,
+            timestamps=_parse_bool(timestamps),
+            context=context or "",
+        )
+        state.jobs[job_id] = job
+
+        # Enqueue
+        await state.job_queue.put(job_id)
+
+        return {
+            "job_id": job_id,
+            "status": job.status.value,
+            "created_at": _format_time(job.created_at),
+        }
+
+    @app.get("/jobs/{job_id}")
+    async def get_job(request: Request, job_id: str) -> dict:
+        _check_auth(request)
+        # Polling does NOT count against rate limit
+
+        job = state.jobs.get(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail="Job not found")
+
+        resp: dict = {
+            "job_id": job.job_id,
+            "status": job.status.value,
+            "created_at": _format_time(job.created_at),
+        }
+
+        if job.status == JobStatus.COMPLETED:
+            resp["completed_at"] = _format_time(job.completed_at)
+            resp["result"] = job.result
+        elif job.status == JobStatus.FAILED:
+            resp["completed_at"] = _format_time(job.completed_at)
+            resp["error"] = job.error
+
+        return resp
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _result_to_dict(result: object) -> dict:
+    """Convert TranscriptionResult to a JSON-serializable dict.
+
+    Passes through the library output as-is — no translation layer.
+    None fields are omitted from the response.
+    """
+    from .transcribe import TranscriptionResult
+
+    if isinstance(result, TranscriptionResult):
+        d = asdict(result)
+    else:
+        d = dict(result)  # type: ignore[arg-type]
+    # Strip None values for cleaner responses
+    return {k: v for k, v in d.items() if v is not None}
+
+
+def _parse_bool(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.lower() in ("true", "1", "yes")
+
+
+def _format_time(ts: Optional[float]) -> Optional[str]:
+    if ts is None:
+        return None
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _cleanup_temp(job: Job) -> None:
+    if job.temp_path:
+        Path(job.temp_path).unlink(missing_ok=True)
+        job.temp_path = None
+
+
+# ---------------------------------------------------------------------------
+# Entry point (called from CLI)
+# ---------------------------------------------------------------------------
+
+def run_server(config: ServerConfig) -> None:
+    """Start the server with uvicorn."""
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise ImportError(
+            "Server dependencies not installed. "
+            'Install with: pip install "mlx-qwen3-asr[serve]"'
+        ) from exc
+
+    if not config.api_keys:
+        raise SystemExit(
+            "Error: at least one API key is required (--api-key or MLX_ASR_API_KEY)"
+        )
+
+    app = create_app(config)
+    logger.info(
+        "Starting server on %s:%d (model=%s, max_queue=%d)",
+        config.host, config.port, config.model, config.max_queue_depth,
+    )
+    uvicorn.run(app, host=config.host, port=config.port, log_level="info")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 aligner = ["nagisa", "soynlp"]
 diarize = ["pyannote.audio>=3.3.2"]
 mic = ["sounddevice>=0.4.6"]
+serve = ["fastapi>=0.100.0", "uvicorn>=0.20.0", "python-multipart>=0.0.5"]
 dev = ["pytest", "ruff", "mypy"]
 eval = ["soundfile>=0.12.1", "pyarrow>=18.0.0"]
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1157,3 +1157,128 @@ async def test_openai_model_field_accepted():
         )
         assert resp.status_code == 200
         assert resp.json()["text"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_openai_500_on_transcription_failure():
+    """OpenAI compat returns 500 when transcription fails."""
+    session = MagicMock()
+    session.transcribe_async = AsyncMock(
+        side_effect=RuntimeError("Audio is corrupted")
+    )
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("bad.wav", b"RIFF" * 10, "audio/wav")},
+        )
+        assert resp.status_code == 500
+        assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_openai_verbose_json_includes_segments():
+    """verbose_json includes segments from chunks."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+    session.transcribe_async = AsyncMock(
+        return_value=TranscriptionResult(
+            text="Hello world",
+            language="English",
+            segments=[
+                {"text": "Hello", "start": 0.0, "end": 0.5},
+                {"text": "world", "start": 0.5, "end": 1.0},
+            ],
+            chunks=[{
+                "text": "Hello world",
+                "start": 0.0,
+                "end": 1.0,
+                "chunk_index": 0,
+                "language": "English",
+            }],
+        )
+    )
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            data={"response_format": "verbose_json"},
+        )
+        data = resp.json()
+        assert "segments" in data
+        assert data["segments"][0]["id"] == 0
+        assert data["segments"][0]["text"] == "Hello world"
+        assert "words" in data
+
+
+@pytest.mark.asyncio
+async def test_openai_backpressure_returns_503():
+    """OpenAI compat returns 503 when server is at capacity."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+
+    async def slow_transcribe(*args, **kwargs):
+        await asyncio.sleep(10)
+        return TranscriptionResult(text="done", language="English")
+
+    session.transcribe_async = slow_transcribe
+
+    async with _create_test_app_with_worker(
+        max_queue_depth=1, mock_session_obj=session
+    ) as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": "Bearer testkey"}
+            audio = ("test.wav", b"RIFF" * 10, "audio/wav")
+
+            # Fill native queue: submit a job to occupy the worker
+            resp1 = await client.post(
+                "/transcribe", headers=headers, files={"audio": audio}
+            )
+            assert resp1.status_code == 202
+            await asyncio.sleep(0.1)
+
+            # Fill queue slot
+            resp2 = await client.post(
+                "/transcribe", headers=headers, files={"audio": audio}
+            )
+            assert resp2.status_code == 202
+
+            # OpenAI endpoint should get 503
+            resp3 = await client.post(
+                "/v1/audio/transcriptions", headers=headers, files={"file": audio}
+            )
+            assert resp3.status_code == 503
+            assert "Retry-After" in resp3.headers
+
+
+@pytest.mark.asyncio
+async def test_openai_verbose_json_no_segments():
+    """verbose_json omits words key when no timestamps available."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+    session.transcribe_async = AsyncMock(
+        return_value=TranscriptionResult(text="Hello", language="English")
+    )
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            data={"response_format": "verbose_json"},
+        )
+        data = resp.json()
+        assert data["task"] == "transcribe"
+        assert data["text"] == "Hello"
+        assert "words" not in data
+        assert "segments" not in data

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,6 +19,8 @@ from mlx_qwen3_asr.server import (
     _parse_bool,
     _RateLimiter,
     _result_to_dict,
+    _sanitize_error,
+    _validate_config,
     create_app,
 )
 
@@ -37,14 +39,17 @@ class TestParseBool:
     def test_true_values(self):
         assert _parse_bool("true") is True
         assert _parse_bool("True") is True
+        assert _parse_bool("TRUE") is True
         assert _parse_bool("1") is True
         assert _parse_bool("yes") is True
+        assert _parse_bool("YES") is True
 
     def test_false_values(self):
         assert _parse_bool("false") is False
         assert _parse_bool("0") is False
         assert _parse_bool("no") is False
         assert _parse_bool(None) is False
+        assert _parse_bool("anything") is False
 
 
 class TestFormatTime:
@@ -53,13 +58,14 @@ class TestFormatTime:
 
     def test_epoch(self):
         result = _format_time(0.0)
-        assert result is not None
-        assert "1970" in result
+        assert result == "1970-01-01T00:00:00Z"
 
-    def test_iso_format(self):
+    def test_z_suffix(self):
+        """Timestamps must end with Z, not +00:00."""
         result = _format_time(1710936000.0)
         assert result is not None
-        assert "T" in result
+        assert result.endswith("Z")
+        assert "+00:00" not in result
 
 
 class TestResultToDict:
@@ -81,6 +87,24 @@ class TestResultToDict:
         )
         d = _result_to_dict(result)
         assert d["segments"] == segments
+
+
+class TestSanitizeError:
+    def test_safe_message_passes_through(self):
+        exc = RuntimeError("Audio is corrupted")
+        assert _sanitize_error(exc) == "Audio is corrupted"
+
+    def test_path_leak_is_sanitized(self):
+        exc = RuntimeError("Failed to open /tmp/mlx_asr_abc123.wav")
+        result = _sanitize_error(exc)
+        assert "/tmp/" not in result
+        assert "RuntimeError" in result
+
+    def test_home_path_is_sanitized(self):
+        exc = ValueError("No such file: /Users/alice/secret/model.bin")
+        result = _sanitize_error(exc)
+        assert "/Users/" not in result
+        assert "ValueError" in result
 
 
 class TestCleanupTemp:
@@ -149,7 +173,7 @@ class TestRateLimiter:
 
 
 # ---------------------------------------------------------------------------
-# ServerConfig tests
+# ServerConfig + validation tests
 # ---------------------------------------------------------------------------
 
 
@@ -167,6 +191,37 @@ class TestServerConfig:
     def test_multiple_keys(self):
         config = ServerConfig(api_keys=["key1", "key2", "key3"])
         assert len(config.api_keys) == 3
+
+
+class TestValidateConfig:
+    def test_valid_config_passes(self):
+        config = ServerConfig(api_keys=["key1"])
+        _validate_config(config)  # should not raise
+
+    def test_no_api_keys(self):
+        config = ServerConfig(api_keys=[])
+        with pytest.raises(SystemExit, match="at least one API key"):
+            _validate_config(config)
+
+    def test_zero_rate_limit(self):
+        config = ServerConfig(api_keys=["k"], rate_limit=0)
+        with pytest.raises(SystemExit, match="rate-limit"):
+            _validate_config(config)
+
+    def test_zero_queue_depth(self):
+        config = ServerConfig(api_keys=["k"], max_queue_depth=0)
+        with pytest.raises(SystemExit, match="max-queue-depth"):
+            _validate_config(config)
+
+    def test_negative_values(self):
+        config = ServerConfig(api_keys=["k"], max_file_size_mb=-1)
+        with pytest.raises(SystemExit, match="max-file-size"):
+            _validate_config(config)
+
+    def test_invalid_port(self):
+        config = ServerConfig(api_keys=["k"], port=99999)
+        with pytest.raises(SystemExit, match="port"):
+            _validate_config(config)
 
 
 # ---------------------------------------------------------------------------
@@ -298,6 +353,7 @@ async def test_health_no_auth_required():
         assert data["status"] == "ok"
         assert data["model"] == "Qwen/Qwen3-ASR-0.6B"
         assert "queued_jobs" in data
+        assert "processing_jobs" in data
         assert "max_queue_depth" in data
 
 
@@ -406,6 +462,9 @@ async def test_full_job_lifecycle():
             assert data["status"] == "queued"
             job_id = data["job_id"]
 
+            # Job ID should be full UUID length (j_ + 32 hex chars)
+            assert len(job_id) == 34
+
             # Poll until done (max 5 seconds)
             for _ in range(50):
                 resp = await client.get(f"/jobs/{job_id}", headers=headers)
@@ -418,8 +477,9 @@ async def test_full_job_lifecycle():
             assert data["status"] == "completed"
             assert data["result"]["text"] == "Hello world"
             assert data["result"]["language"] == "English"
-            assert "chunks" in data["result"]
             assert "completed_at" in data
+            # Timestamps should use Z suffix
+            assert data["completed_at"].endswith("Z")
 
 
 @pytest.mark.asyncio
@@ -463,7 +523,7 @@ async def test_job_passes_language_and_timestamps():
 
 @pytest.mark.asyncio
 async def test_backpressure_returns_503():
-    """Queue full returns 503."""
+    """Queue full returns 503 via atomic put_nowait."""
     from mlx_qwen3_asr.transcribe import TranscriptionResult
 
     session = MagicMock()
@@ -529,6 +589,36 @@ async def test_multiple_api_keys():
 
 
 @pytest.mark.asyncio
+async def test_job_isolation_cross_key():
+    """Key2 cannot read key1's job — returns 404."""
+    async with _create_test_app_with_worker(api_keys=["key1", "key2"]) as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # key1 submits a job
+            resp = await client.post(
+                "/transcribe",
+                headers={"Authorization": "Bearer key1"},
+                files={"audio": ("test.wav", b"RIFF" * 10, "audio/wav")},
+            )
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
+
+            # key1 can read their own job
+            resp = await client.get(
+                f"/jobs/{job_id}",
+                headers={"Authorization": "Bearer key1"},
+            )
+            assert resp.status_code == 200
+
+            # key2 cannot read key1's job
+            resp = await client.get(
+                f"/jobs/{job_id}",
+                headers={"Authorization": "Bearer key2"},
+            )
+            assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_failed_job_returns_error():
     """Failed transcription returns error in job response."""
     session = MagicMock()
@@ -557,7 +647,7 @@ async def test_failed_job_returns_error():
                 await asyncio.sleep(0.1)
 
             assert data["status"] == "failed"
-            assert "Audio is corrupted" in data["error"]
+            assert "error" in data
             assert "completed_at" in data
 
 
@@ -586,6 +676,45 @@ async def test_temp_file_cleaned_after_completion():
             # The job's temp_path should be cleaned up
             job = app.state.server.jobs[job_id]
             assert job.temp_path is None
+
+
+@pytest.mark.asyncio
+async def test_backpressure_cleans_up_on_503():
+    """When 503 is returned, the temp file and job entry are cleaned up."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+
+    async def slow_transcribe(*args, **kwargs):
+        await asyncio.sleep(10)
+        return TranscriptionResult(text="done", language="English")
+
+    session.transcribe_async = slow_transcribe
+
+    async with _create_test_app_with_worker(
+        max_queue_depth=1, mock_session_obj=session
+    ) as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": "Bearer testkey"}
+            audio = ("test.wav", b"RIFF" * 10, "audio/wav")
+
+            # Fill up
+            await client.post("/transcribe", headers=headers, files={"audio": audio})
+            await asyncio.sleep(0.1)
+            await client.post("/transcribe", headers=headers, files={"audio": audio})
+
+            # Count jobs before 503
+            jobs_before = len(app.state.server.jobs)
+
+            # This gets 503
+            resp = await client.post(
+                "/transcribe", headers=headers, files={"audio": audio}
+            )
+            assert resp.status_code == 503
+
+            # No extra job was left in the store
+            assert len(app.state.server.jobs) == jobs_before
 
 
 # ---------------------------------------------------------------------------
@@ -665,4 +794,22 @@ def test_run_server_requires_api_key():
 
     config = ServerConfig(api_keys=[])
     with pytest.raises(SystemExit, match="at least one API key"):
+        run_server(config)
+
+
+def test_run_server_rejects_zero_rate_limit():
+    """run_server exits if rate_limit is 0."""
+    from mlx_qwen3_asr.server import run_server
+
+    config = ServerConfig(api_keys=["k"], rate_limit=0)
+    with pytest.raises(SystemExit, match="rate-limit"):
+        run_server(config)
+
+
+def test_run_server_rejects_zero_queue_depth():
+    """run_server exits if max_queue_depth is 0."""
+    from mlx_qwen3_asr.server import run_server
+
+    config = ServerConfig(api_keys=["k"], max_queue_depth=0)
+    with pytest.raises(SystemExit, match="max-queue-depth"):
         run_server(config)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,7 +15,10 @@ from mlx_qwen3_asr.server import (
     ServerConfig,
     _AppState,
     _cleanup_temp,
+    _estimate_duration,
+    _format_srt,
     _format_time,
+    _format_vtt,
     _parse_bool,
     _RateLimiter,
     _result_to_dict,
@@ -813,3 +816,344 @@ def test_run_server_rejects_zero_queue_depth():
     config = ServerConfig(api_keys=["k"], max_queue_depth=0)
     with pytest.raises(SystemExit, match="max-queue-depth"):
         run_server(config)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible response helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateDuration:
+    def test_from_segments(self):
+        from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+        result = TranscriptionResult(
+            text="hi", language="en",
+            segments=[{"text": "hi", "start": 0.0, "end": 2.5}],
+        )
+        assert _estimate_duration(result) == 2.5
+
+    def test_from_chunks(self):
+        from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+        result = TranscriptionResult(
+            text="hi", language="en",
+            chunks=[{"text": "hi", "start": 0.0, "end": 5.0}],
+        )
+        assert _estimate_duration(result) == 5.0
+
+    def test_no_timestamps(self):
+        from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+        result = TranscriptionResult(text="hi", language="en")
+        assert _estimate_duration(result) == 0.0
+
+
+class TestFormatSrt:
+    def test_basic(self):
+        segments = [
+            {"text": "Hello world", "start": 0.0, "end": 1.0},
+            {"text": "How are you", "start": 1.5, "end": 2.5},
+        ]
+        srt = _format_srt(segments)
+        assert "1\n00:00:00,000 --> 00:00:01,000\nHello world" in srt
+        assert "2\n00:00:01,500 --> 00:00:02,500\nHow are you" in srt
+
+    def test_empty(self):
+        assert _format_srt([]) == ""
+
+
+class TestFormatVtt:
+    def test_basic(self):
+        segments = [
+            {"text": "Hello world", "start": 0.0, "end": 1.0},
+        ]
+        vtt = _format_vtt(segments)
+        assert vtt.startswith("WEBVTT")
+        assert "00:00:00.000 --> 00:00:01.000" in vtt
+        assert "Hello world" in vtt
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_json_default():
+    """OpenAI compat returns JSON with text field by default."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"text": "Hello world"}
+
+
+@pytest.mark.asyncio
+async def test_openai_text_format():
+    """OpenAI compat returns plain text when response_format=text."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            data={"response_format": "text"},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "Hello world"
+        assert "text/plain" in resp.headers.get("content-type", "")
+
+
+@pytest.mark.asyncio
+async def test_openai_verbose_json():
+    """OpenAI compat verbose_json includes words and duration."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+    session.transcribe_async = AsyncMock(
+        return_value=TranscriptionResult(
+            text="Hello world",
+            language="English",
+            segments=[
+                {"text": "Hello", "start": 0.0, "end": 0.5},
+                {"text": "world", "start": 0.5, "end": 1.0},
+            ],
+        )
+    )
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            data={"response_format": "verbose_json"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["task"] == "transcribe"
+        assert data["language"] == "english"
+        assert data["text"] == "Hello world"
+        assert data["duration"] == 1.0
+        assert len(data["words"]) == 2
+        assert data["words"][0] == {"word": "Hello", "start": 0.0, "end": 0.5}
+
+
+@pytest.mark.asyncio
+async def test_openai_srt_format():
+    """OpenAI compat returns SRT subtitles."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+    session.transcribe_async = AsyncMock(
+        return_value=TranscriptionResult(
+            text="Hello world",
+            language="English",
+            segments=[
+                {"text": "Hello", "start": 0.0, "end": 0.5},
+                {"text": "world", "start": 0.5, "end": 1.0},
+            ],
+        )
+    )
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            data={"response_format": "srt"},
+        )
+        assert resp.status_code == 200
+        assert "text/plain" in resp.headers.get("content-type", "")
+        assert "00:00:00,000" in resp.text
+        assert "-->" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_openai_vtt_format():
+    """OpenAI compat returns WebVTT subtitles."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+    session.transcribe_async = AsyncMock(
+        return_value=TranscriptionResult(
+            text="Hello world",
+            language="English",
+            segments=[
+                {"text": "Hello", "start": 0.0, "end": 0.5},
+                {"text": "world", "start": 0.5, "end": 1.0},
+            ],
+        )
+    )
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            data={"response_format": "vtt"},
+        )
+        assert resp.status_code == 200
+        assert "WEBVTT" in resp.text
+        assert "00:00:00.000" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_openai_requires_auth():
+    """OpenAI compat endpoint requires authentication."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", b"RIFF" * 10, "audio/wav")},
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_openai_rejects_bad_key():
+    """OpenAI compat endpoint rejects invalid API key."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer wrongkey"},
+            files={"file": ("test.wav", b"RIFF" * 10, "audio/wav")},
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_openai_rate_limited():
+    """OpenAI compat respects rate limiting."""
+    app = _create_test_app(rate_limit=1)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer testkey"}
+        audio = ("test.wav", b"RIFF" * 10, "audio/wav")
+
+        # First request uses the rate limit
+        await client.post(
+            "/v1/audio/transcriptions", headers=headers, files={"file": audio}
+        )
+        # Second should be limited
+        resp = await client.post(
+            "/v1/audio/transcriptions", headers=headers, files={"file": audio}
+        )
+        assert resp.status_code == 429
+        assert "Retry-After" in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_openai_prompt_maps_to_context():
+    """OpenAI 'prompt' field maps to our 'context' parameter."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    captured = {}
+
+    async def capture(*args, **kwargs):
+        captured.update(kwargs)
+        return TranscriptionResult(text="ok", language="English")
+
+    session = MagicMock()
+    session.transcribe_async = capture
+
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 10, "audio/wav")},
+            data={"prompt": "Medical terminology"},
+        )
+
+    assert captured.get("context") == "Medical terminology"
+
+
+@pytest.mark.asyncio
+async def test_openai_verbose_json_enables_timestamps():
+    """verbose_json format automatically enables timestamp generation."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    captured = {}
+
+    async def capture(*args, **kwargs):
+        captured.update(kwargs)
+        return TranscriptionResult(
+            text="ok", language="English",
+            segments=[{"text": "ok", "start": 0.0, "end": 0.5}],
+        )
+
+    session = MagicMock()
+    session.transcribe_async = capture
+
+    app = _create_test_app(mock_session_obj=session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 10, "audio/wav")},
+            data={"response_format": "verbose_json"},
+        )
+
+    assert captured.get("return_timestamps") is True
+
+
+@pytest.mark.asyncio
+async def test_openai_invalid_format():
+    """OpenAI compat rejects invalid response_format."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 10, "audio/wav")},
+            data={"response_format": "xml"},
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_openai_file_size_limit():
+    """OpenAI compat respects file size limits."""
+    app = _create_test_app(max_file_size_mb=1)
+    big_data = b"x" * (2 * 1024 * 1024)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", big_data, "audio/wav")},
+        )
+        assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_openai_model_field_accepted():
+    """OpenAI compat accepts model field without error."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/audio/transcriptions",
+            headers={"Authorization": "Bearer testkey"},
+            files={"file": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            data={"model": "Qwen/Qwen3-ASR-1.7B"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["text"] == "Hello world"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,668 @@
+"""Tests for mlx_qwen3_asr/server.py — transcription HTTP server."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mlx_qwen3_asr.server import (
+    Job,
+    JobStatus,
+    ServerConfig,
+    _AppState,
+    _cleanup_temp,
+    _format_time,
+    _parse_bool,
+    _RateLimiter,
+    _result_to_dict,
+    create_app,
+)
+
+# Skip all tests if fastapi/httpx not installed
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseBool:
+    def test_true_values(self):
+        assert _parse_bool("true") is True
+        assert _parse_bool("True") is True
+        assert _parse_bool("1") is True
+        assert _parse_bool("yes") is True
+
+    def test_false_values(self):
+        assert _parse_bool("false") is False
+        assert _parse_bool("0") is False
+        assert _parse_bool("no") is False
+        assert _parse_bool(None) is False
+
+
+class TestFormatTime:
+    def test_none(self):
+        assert _format_time(None) is None
+
+    def test_epoch(self):
+        result = _format_time(0.0)
+        assert result is not None
+        assert "1970" in result
+
+    def test_iso_format(self):
+        result = _format_time(1710936000.0)
+        assert result is not None
+        assert "T" in result
+
+
+class TestResultToDict:
+    def test_strips_none_fields(self):
+        from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+        result = TranscriptionResult(text="hello", language="English")
+        d = _result_to_dict(result)
+        assert d == {"text": "hello", "language": "English"}
+        assert "segments" not in d
+        assert "chunks" not in d
+
+    def test_preserves_non_none_fields(self):
+        from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+        segments = [{"text": "hello", "start": 0.0, "end": 1.0}]
+        result = TranscriptionResult(
+            text="hello", language="English", segments=segments
+        )
+        d = _result_to_dict(result)
+        assert d["segments"] == segments
+
+
+class TestCleanupTemp:
+    def test_removes_file(self, tmp_path):
+        f = tmp_path / "test.wav"
+        f.write_bytes(b"data")
+        job = Job(
+            job_id="j_test",
+            status=JobStatus.COMPLETED,
+            created_at=time.time(),
+            temp_path=str(f),
+        )
+        _cleanup_temp(job)
+        assert not f.exists()
+        assert job.temp_path is None
+
+    def test_handles_missing_file(self):
+        job = Job(
+            job_id="j_test",
+            status=JobStatus.COMPLETED,
+            created_at=time.time(),
+            temp_path="/nonexistent/file.wav",
+        )
+        _cleanup_temp(job)
+        assert job.temp_path is None
+
+    def test_handles_no_temp_path(self):
+        job = Job(
+            job_id="j_test",
+            status=JobStatus.COMPLETED,
+            created_at=time.time(),
+        )
+        _cleanup_temp(job)
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter tests
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiter:
+    def test_allows_under_limit(self):
+        rl = _RateLimiter(max_requests=3, window_sec=60.0)
+        assert rl.is_allowed("key1") is True
+        assert rl.is_allowed("key1") is True
+        assert rl.is_allowed("key1") is True
+
+    def test_blocks_over_limit(self):
+        rl = _RateLimiter(max_requests=2, window_sec=60.0)
+        assert rl.is_allowed("key1") is True
+        assert rl.is_allowed("key1") is True
+        assert rl.is_allowed("key1") is False
+
+    def test_keys_are_independent(self):
+        rl = _RateLimiter(max_requests=1, window_sec=60.0)
+        assert rl.is_allowed("key1") is True
+        assert rl.is_allowed("key2") is True
+        assert rl.is_allowed("key1") is False
+
+    def test_retry_after_returns_positive(self):
+        rl = _RateLimiter(max_requests=1, window_sec=60.0)
+        rl.is_allowed("key1")
+        rl.is_allowed("key1")
+        retry = rl.retry_after("key1")
+        assert retry > 0
+
+
+# ---------------------------------------------------------------------------
+# ServerConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestServerConfig:
+    def test_defaults(self):
+        config = ServerConfig(api_keys=["key1"])
+        assert config.host == "0.0.0.0"
+        assert config.port == 8765
+        assert config.rate_limit == 60
+        assert config.max_file_size_mb == 200
+        assert config.max_duration_sec == 1800
+        assert config.max_queue_depth == 10
+        assert config.job_ttl_sec == 3600
+
+    def test_multiple_keys(self):
+        config = ServerConfig(api_keys=["key1", "key2", "key3"])
+        assert len(config.api_keys) == 3
+
+
+# ---------------------------------------------------------------------------
+# Test helpers for HTTP integration tests
+# ---------------------------------------------------------------------------
+
+def _mock_session():
+    """Create a mock Session returning a fixed TranscriptionResult."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    mock = MagicMock()
+    mock.transcribe_async = AsyncMock(
+        return_value=TranscriptionResult(
+            text="Hello world",
+            language="English",
+            chunks=[{
+                "text": "Hello world",
+                "start": 0.0,
+                "end": 2.5,
+                "chunk_index": 0,
+                "language": "English",
+            }],
+        )
+    )
+    return mock
+
+
+async def _run_worker(s: _AppState) -> None:
+    """Background worker for tests — processes jobs sequentially."""
+    while True:
+        job_id = await s.job_queue.get()
+        job = s.jobs.get(job_id)
+        if job is None or job.status != JobStatus.QUEUED:
+            s.job_queue.task_done()
+            continue
+        job.status = JobStatus.PROCESSING
+        try:
+            result = await s.session.transcribe_async(
+                job.temp_path,
+                language=job.language,
+                context=job.context,
+                return_timestamps=job.timestamps,
+                return_chunks=True,
+            )
+            job.result = _result_to_dict(result)
+            job.status = JobStatus.COMPLETED
+            job.completed_at = time.time()
+        except Exception as exc:
+            job.status = JobStatus.FAILED
+            job.completed_at = time.time()
+            job.error = str(exc)
+        finally:
+            _cleanup_temp(job)
+            s.job_queue.task_done()
+
+
+def _create_test_app(
+    api_keys: list[str] | None = None,
+    rate_limit: int = 60,
+    max_file_size_mb: int = 200,
+    max_queue_depth: int = 10,
+    mock_session_obj: object | None = None,
+):
+    """Create a test app that skips model loading and uses a mock Session.
+
+    IMPORTANT: httpx ASGITransport does not trigger lifespan events.
+    For tests that need the job worker, use ``_create_test_app_with_worker``
+    instead (an async context manager).
+    """
+    config = ServerConfig(
+        api_keys=api_keys or ["testkey"],
+        rate_limit=rate_limit,
+        max_file_size_mb=max_file_size_mb,
+        max_queue_depth=max_queue_depth,
+    )
+    app = create_app(config)
+
+    # Inject mock session directly into app state (no lifespan needed)
+    session = mock_session_obj or _mock_session()
+    app.state.server.session = session
+
+    return app
+
+
+@asynccontextmanager
+async def _create_test_app_with_worker(
+    api_keys: list[str] | None = None,
+    rate_limit: int = 60,
+    max_file_size_mb: int = 200,
+    max_queue_depth: int = 10,
+    mock_session_obj: object | None = None,
+):
+    """Create a test app with a running background worker.
+
+    Use as: ``async with _create_test_app_with_worker() as app: ...``
+    """
+    app = _create_test_app(
+        api_keys=api_keys,
+        rate_limit=rate_limit,
+        max_file_size_mb=max_file_size_mb,
+        max_queue_depth=max_queue_depth,
+        mock_session_obj=mock_session_obj,
+    )
+    worker_task = asyncio.create_task(_run_worker(app.state.server))
+    try:
+        yield app
+    finally:
+        worker_task.cancel()
+        try:
+            await worker_task
+        except asyncio.CancelledError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_no_auth_required():
+    """Health endpoint works without auth."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["model"] == "Qwen/Qwen3-ASR-0.6B"
+        assert "queued_jobs" in data
+        assert "max_queue_depth" in data
+
+
+@pytest.mark.asyncio
+async def test_transcribe_requires_auth():
+    """Transcribe endpoint rejects unauthenticated requests."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/transcribe",
+            files={"audio": ("test.wav", b"RIFF" * 10, "audio/wav")},
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_transcribe_rejects_bad_key():
+    """Transcribe endpoint rejects invalid API key."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/transcribe",
+            headers={"Authorization": "Bearer wrongkey"},
+            files={"audio": ("test.wav", b"RIFF" * 10, "audio/wav")},
+        )
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_transcribe_rejects_oversized_file():
+    """Transcribe rejects files exceeding max_file_size_mb."""
+    app = _create_test_app(max_file_size_mb=1)
+    big_data = b"x" * (2 * 1024 * 1024)  # 2 MB
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/transcribe",
+            headers={"Authorization": "Bearer testkey"},
+            files={"audio": ("test.wav", big_data, "audio/wav")},
+        )
+        assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_jobs_requires_auth():
+    """Jobs endpoint rejects unauthenticated requests."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/jobs/j_nonexistent")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_jobs_returns_404_for_unknown():
+    """Jobs endpoint returns 404 for unknown job IDs."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/jobs/j_nonexistent",
+            headers={"Authorization": "Bearer testkey"},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_returns_429():
+    """Rate limiter returns 429 when exceeded."""
+    app = _create_test_app(rate_limit=1)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer testkey"}
+        audio = ("test.wav", b"RIFF" * 10, "audio/wav")
+
+        # First request uses the rate limit
+        await client.post("/transcribe", headers=headers, files={"audio": audio})
+        # Second request should be rate-limited
+        resp2 = await client.post(
+            "/transcribe", headers=headers, files={"audio": audio}
+        )
+        assert resp2.status_code == 429
+        assert "Retry-After" in resp2.headers
+
+
+@pytest.mark.asyncio
+async def test_full_job_lifecycle():
+    """End-to-end: submit job, poll until completed, verify result."""
+    async with _create_test_app_with_worker() as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": "Bearer testkey"}
+
+            # Submit
+            resp = await client.post(
+                "/transcribe",
+                headers=headers,
+                files={"audio": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            )
+            assert resp.status_code == 202
+            data = resp.json()
+            assert "job_id" in data
+            assert data["status"] == "queued"
+            job_id = data["job_id"]
+
+            # Poll until done (max 5 seconds)
+            for _ in range(50):
+                resp = await client.get(f"/jobs/{job_id}", headers=headers)
+                assert resp.status_code == 200
+                data = resp.json()
+                if data["status"] in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.1)
+
+            assert data["status"] == "completed"
+            assert data["result"]["text"] == "Hello world"
+            assert data["result"]["language"] == "English"
+            assert "chunks" in data["result"]
+            assert "completed_at" in data
+
+
+@pytest.mark.asyncio
+async def test_job_passes_language_and_timestamps():
+    """Verify that language and timestamps params reach the Session."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+    captured_kwargs = {}
+
+    async def capture_transcribe(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return TranscriptionResult(text="ok", language="Japanese")
+
+    session.transcribe_async = capture_transcribe
+
+    async with _create_test_app_with_worker(mock_session_obj=session) as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": "Bearer testkey"}
+            resp = await client.post(
+                "/transcribe",
+                headers=headers,
+                files={"audio": ("test.wav", b"RIFF" * 10, "audio/wav")},
+                data={"language": "ja", "timestamps": "true", "context": "ASR test"},
+            )
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
+
+            # Wait for processing
+            for _ in range(50):
+                resp = await client.get(f"/jobs/{job_id}", headers=headers)
+                if resp.json()["status"] in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.1)
+
+    assert captured_kwargs.get("language") == "ja"
+    assert captured_kwargs.get("return_timestamps") is True
+    assert captured_kwargs.get("context") == "ASR test"
+
+
+@pytest.mark.asyncio
+async def test_backpressure_returns_503():
+    """Queue full returns 503."""
+    from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+    session = MagicMock()
+
+    async def slow_transcribe(*args, **kwargs):
+        await asyncio.sleep(10)
+        return TranscriptionResult(text="done", language="English")
+
+    session.transcribe_async = slow_transcribe
+
+    async with _create_test_app_with_worker(
+        max_queue_depth=1, mock_session_obj=session
+    ) as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": "Bearer testkey"}
+            audio = ("test.wav", b"RIFF" * 10, "audio/wav")
+
+            # Fill the queue (1 processing + queue is full)
+            resp1 = await client.post(
+                "/transcribe", headers=headers, files={"audio": audio}
+            )
+            assert resp1.status_code == 202
+
+            # Give worker time to pick it up (frees queue slot)
+            await asyncio.sleep(0.1)
+
+            # This fills the queue slot again
+            resp2 = await client.post(
+                "/transcribe", headers=headers, files={"audio": audio}
+            )
+            assert resp2.status_code == 202
+
+            # This should get 503
+            resp3 = await client.post(
+                "/transcribe", headers=headers, files={"audio": audio}
+            )
+            assert resp3.status_code == 503
+            assert "Retry-After" in resp3.headers
+
+
+@pytest.mark.asyncio
+async def test_multiple_api_keys():
+    """Multiple API keys all work."""
+    async with _create_test_app_with_worker(api_keys=["key1", "key2"]) as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            audio = ("test.wav", b"RIFF" * 10, "audio/wav")
+
+            resp1 = await client.post(
+                "/transcribe",
+                headers={"Authorization": "Bearer key1"},
+                files={"audio": audio},
+            )
+            assert resp1.status_code == 202
+
+            resp2 = await client.post(
+                "/transcribe",
+                headers={"Authorization": "Bearer key2"},
+                files={"audio": audio},
+            )
+            assert resp2.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_failed_job_returns_error():
+    """Failed transcription returns error in job response."""
+    session = MagicMock()
+    session.transcribe_async = AsyncMock(
+        side_effect=RuntimeError("Audio is corrupted")
+    )
+
+    async with _create_test_app_with_worker(mock_session_obj=session) as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": "Bearer testkey"}
+
+            resp = await client.post(
+                "/transcribe",
+                headers=headers,
+                files={"audio": ("bad.wav", b"RIFF" * 10, "audio/wav")},
+            )
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
+
+            for _ in range(50):
+                resp = await client.get(f"/jobs/{job_id}", headers=headers)
+                data = resp.json()
+                if data["status"] in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.1)
+
+            assert data["status"] == "failed"
+            assert "Audio is corrupted" in data["error"]
+            assert "completed_at" in data
+
+
+@pytest.mark.asyncio
+async def test_temp_file_cleaned_after_completion():
+    """Temp file is deleted after job completes."""
+    async with _create_test_app_with_worker() as app:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": "Bearer testkey"}
+
+            resp = await client.post(
+                "/transcribe",
+                headers=headers,
+                files={"audio": ("test.wav", b"RIFF" * 100, "audio/wav")},
+            )
+            job_id = resp.json()["job_id"]
+
+            # Wait for completion
+            for _ in range(50):
+                resp = await client.get(f"/jobs/{job_id}", headers=headers)
+                if resp.json()["status"] in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.1)
+
+            # The job's temp_path should be cleaned up
+            job = app.state.server.jobs[job_id]
+            assert job.temp_path is None
+
+
+# ---------------------------------------------------------------------------
+# CLI serve subcommand tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_serve_help():
+    """``mlx-qwen3-asr serve --help`` exits cleanly."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mlx_qwen3_asr.cli", "serve", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Start the transcription HTTP server" in result.stdout
+    assert "--api-key" in result.stdout
+    assert "--port" in result.stdout
+    assert "--max-queue-depth" in result.stdout
+    assert "--job-ttl" in result.stdout
+
+
+def test_cli_serve_parses_all_flags():
+    """Serve subcommand parses all flags into ServerConfig."""
+
+    from mlx_qwen3_asr.cli import _parse_serve_args
+
+    with patch("mlx_qwen3_asr.server.run_server") as mock_run:
+        _parse_serve_args([
+            "--host", "127.0.0.1",
+            "--port", "9999",
+            "--api-key", "k1,k2",
+            "--model", "Qwen/Qwen3-ASR-1.7B",
+            "--dtype", "bfloat16",
+            "--rate-limit", "30",
+            "--max-file-size", "100",
+            "--max-duration", "600",
+            "--max-queue-depth", "5",
+            "--job-ttl", "7200",
+        ])
+
+    config = mock_run.call_args[0][0]
+    assert config.host == "127.0.0.1"
+    assert config.port == 9999
+    assert config.api_keys == ["k1", "k2"]
+    assert config.model == "Qwen/Qwen3-ASR-1.7B"
+    assert config.dtype == "bfloat16"
+    assert config.rate_limit == 30
+    assert config.max_file_size_mb == 100
+    assert config.max_duration_sec == 600
+    assert config.max_queue_depth == 5
+    assert config.job_ttl_sec == 7200
+
+
+def test_cli_legacy_audio_arg_still_works():
+    """Legacy ``mlx-qwen3-asr audio.wav`` still works."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mlx_qwen3_asr.cli", "nonexistent.wav"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "File not found: nonexistent.wav" in result.stderr
+
+
+def test_run_server_requires_api_key():
+    """run_server exits if no API keys provided."""
+    from mlx_qwen3_asr.server import run_server
+
+    config = ServerConfig(api_keys=[])
+    with pytest.raises(SystemExit, match="at least one API key"):
+        run_server(config)


### PR DESCRIPTION
## Summary

Adds a built-in HTTP server: `mlx-qwen3-asr serve` exposes the transcription pipeline over HTTP. Two endpoint styles:

- **Async job API** — `POST /transcribe` queues a job (202), `GET /jobs/{id}` polls for results. Sequential FIFO processing with backpressure (503 when queue is full). In-memory job store with TTL expiry.
- **OpenAI-compatible endpoint** — `POST /v1/audio/transcriptions` accepts the same fields as the OpenAI Audio API. Existing `openai.audio.transcriptions.create()` code works by changing `base_url`. Supports `json`, `text`, `verbose_json`, `srt`, `vtt` response formats.

Both paths share an `asyncio.Lock` that serializes model inference, a per-key sliding-window rate limiter, and Bearer token auth with job ownership isolation. The server is an optional extra (`pip install mlx-qwen3-asr[serve]`) — core library is unaffected.

### How requests flow

```
Client → POST /transcribe → Queue → Worker → inference_lock → transcribe_async() → Result
Client → POST /v1/audio/transcriptions → inference_lock → transcribe_async() → Result
```

The native API is async (better for long audio — no HTTP timeout risk). The OpenAI endpoint is synchronous (better for SDK compatibility and short clips).

## What's included

| Area | Files | Lines |
|------|-------|-------|
| Server implementation | `server.py` | 697 |
| CLI `serve` subcommand | `cli.py` | +73 |
| Tests (69 total) | `test_server.py` | 1284 |
| API specification | `API-SPEC.md` | 440 |
| Architecture decision record | `ADR-001` | 78 |
| Deployment guide | `DEPLOYMENT.md` | 162 |
| Server README | `README.md` | 138 |
| Package metadata | `pyproject.toml` | +1 |

Relates to #4 — addresses the underlying need for HTTP deployment, including OpenAI SDK compatibility.

## Test plan

- [ ] `python -m pytest tests/test_server.py -x -q` — 69 tests pass
- [ ] `ruff check mlx_qwen3_asr/server.py tests/test_server.py` — lint clean
- [ ] Manual: `mlx-qwen3-asr serve --api-key test` starts, accepts uploads, returns transcriptions
- [ ] Manual: OpenAI Python SDK works with `base_url` pointed at server
- [ ] `pip install mlx-qwen3-asr` (without `[serve]`) — no fastapi pulled in

🤖 Generated with [Claude Code](https://claude.com/claude-code)