### PR TITLE
[codex] Migrate diarization to pyannote.audio 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Install with diarization extras:
 pip install "mlx-qwen3-asr[diarize]"
 ```
 
-Note: `--diarize` uses `pyannote` models. The default model is gated on
-Hugging Face, so you usually need to accept model terms and set a token:
+Note: `--diarize` uses pyannote.audio 4.x and defaults to
+`pyannote/speaker-diarization-community-1`. Accept the model terms on
+Hugging Face and set a token:
 
 ```bash
 export PYANNOTE_AUTH_TOKEN=hf_...
@@ -432,9 +433,11 @@ mlx-qwen3-asr meeting.wav --diarize -f json
 
 Current status:
 - The public API/CLI and output schema are stable.
-- The diarization backend is `pyannote` (installed via `[diarize]` extra).
-- Some pyannote models require Hugging Face token/terms acceptance. Configure
-  `PYANNOTE_AUTH_TOKEN` (or `HF_TOKEN`) when needed.
+- The diarization backend is pyannote.audio 4.x (installed via `[diarize]` extra).
+- The default model is `pyannote/speaker-diarization-community-1`; accept its
+  Hugging Face terms and configure `PYANNOTE_AUTH_TOKEN` (or `HF_TOKEN`).
+- `PYANNOTE_MODEL_ID` can point to another pyannote pipeline or a local
+  offline clone.
 - `--diarize` auto-enables timestamps and is not supported in `--streaming`/`--mic` mode.
 - Migration note (2026-02-15): legacy diarization `window/hop` controls were
   removed (`diarization_window_sec`, `diarization_hop_sec`,
@@ -447,7 +450,8 @@ Current status:
    ```bash
    pip install "mlx-qwen3-asr[diarize]"
    ```
-2. Set a Hugging Face token if your selected diarization model is gated:
+2. Accept the default `pyannote/speaker-diarization-community-1` model terms
+   on Hugging Face and set a token:
    ```bash
    export PYANNOTE_AUTH_TOKEN=hf_...
    ```
@@ -459,7 +463,7 @@ Current status:
 Common errors and fixes:
 - `requires optional dependency 'pyannote.audio'`: install `[diarize]` extra.
 - `requires PyTorch via pyannote dependencies`: reinstall `[diarize]` extra in the active environment.
-- `Failed to initialize pyannote pipeline ...`: accept model terms on Hugging Face and set `PYANNOTE_AUTH_TOKEN` (or `HF_TOKEN`).
+- `Failed to initialize pyannote pipeline ...`: accept model terms on Hugging Face, set `PYANNOTE_AUTH_TOKEN` (or `HF_TOKEN`), and inspect the `Root cause:` details.
 - `--streaming does not support --diarize` / `--mic does not support --diarize`: use offline file transcription mode for diarization.
 
 ## Quantization

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -257,14 +257,17 @@ use `qwen-asr` only in optional parity scripts.
 
 ## Decision 21: Diarization Is Optional and pyannote-First
 
-**Choice:** Use `pyannote.audio` as the runtime diarization backend behind the
-optional extra (`mlx-qwen3-asr[diarize]`), while keeping the core ASR path
+**Choice:** Use pyannote.audio 4.x as the runtime diarization backend behind
+the optional extra (`mlx-qwen3-asr[diarize]`), defaulting to
+`pyannote/speaker-diarization-community-1`, while keeping the core ASR path
 native MLX and torch-free.
 **Alternatives:** (1) keep/expand the native heuristic diarization path, (2)
 remove diarization support entirely.
 
 **Rationale:**
 - Delivers materially better diarization quality now.
+- Tracks pyannote's current open-source pipeline/API rather than freezing a
+  stale 3.x-era dependency stack.
 - Concentrates engineering effort on the core ASR competency.
 - Keeps default install lean and unchanged for users who do not need diarization.
 - Preserves project identity where it matters most: the core ASR inference path.

--- a/mlx_qwen3_asr/cli.py
+++ b/mlx_qwen3_asr/cli.py
@@ -168,8 +168,9 @@ def _run_doctor() -> int:
 
     pyannote_ok = _has_module_spec("pyannote.audio")
     torch_ok = _has_module_spec("torch")
-    if pyannote_ok and torch_ok:
-        print("[OK] diarize extras: pyannote.audio + torch installed")
+    torchcodec_ok = _has_module_spec("torchcodec")
+    if pyannote_ok and torch_ok and torchcodec_ok:
+        print("[OK] diarize extras: pyannote.audio + torch + torchcodec installed")
     else:
         warnings += 1
         print("[WARN] diarize extras: missing (optional)")
@@ -185,7 +186,8 @@ def _run_doctor() -> int:
         print("[OK] diarize auth token: set")
     else:
         warnings += 1
-        print("[WARN] diarize auth token: not set (optional unless using gated pyannote models)")
+        print("[WARN] diarize auth token: not set")
+        print("       needed for default pyannote/speaker-diarization-community-1")
         print("       fix: export PYANNOTE_AUTH_TOKEN=hf_...")
 
     if failures:
@@ -226,8 +228,10 @@ def _preflight_diarization_runtime() -> None:
     if not token:
         print(
             (
-                "Info: --diarize may require Hugging Face auth for gated models. "
-                "Set PYANNOTE_AUTH_TOKEN (or HF_TOKEN) if model access fails."
+                "Info: the default pyannote/speaker-diarization-community-1 "
+                "model requires accepting Hugging Face terms and setting "
+                "PYANNOTE_AUTH_TOKEN (or HF_TOKEN), unless PYANNOTE_MODEL_ID "
+                "points to a local or ungated model."
             ),
             file=sys.stderr,
         )

--- a/mlx_qwen3_asr/diarization.py
+++ b/mlx_qwen3_asr/diarization.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 import os
 import warnings
 from dataclasses import dataclass
+from inspect import signature
 from typing import Any, Optional
 
 import numpy as np
 
 DEFAULT_SPEAKER_LABEL = "SPEAKER_00"
-DEFAULT_PYANNOTE_MODEL_ID = "pyannote/speaker-diarization-3.1"
+DEFAULT_PYANNOTE_MODEL_ID = "pyannote/speaker-diarization-community-1"
 
 
 @dataclass(frozen=True)
@@ -70,11 +71,7 @@ def infer_speaker_turns(
     except TypeError as exc:
         # Some pyannote versions reject speaker-count kwargs.
         if not _is_retryable_kwargs_type_error(exc):
-            raise RuntimeError(
-                "pyannote diarization inference failed. "
-                "Verify the installed '[diarize]' extra and any required "
-                "Hugging Face token/terms for your diarization model."
-            ) from exc
+            raise _diarization_runtime_error(exc) from exc
         warnings.warn(
             "pyannote backend rejected speaker-count kwargs; retrying without them.",
             stacklevel=2,
@@ -82,17 +79,9 @@ def infer_speaker_turns(
         try:
             diarization = pipeline(_pyannote_input(audio_np, sr))
         except Exception as exc:
-            raise RuntimeError(
-                "pyannote diarization inference failed. "
-                "Verify the installed '[diarize]' extra and any required "
-                "Hugging Face token/terms for your diarization model."
-            ) from exc
+            raise _diarization_runtime_error(exc) from exc
     except Exception as exc:
-        raise RuntimeError(
-            "pyannote diarization inference failed. "
-            "Verify the installed '[diarize]' extra and any required "
-            "Hugging Face token/terms for your diarization model."
-        ) from exc
+        raise _diarization_runtime_error(exc) from exc
 
     turns = _annotation_to_turns(diarization, duration=float(audio_np.shape[0] / sr))
     if not turns:
@@ -264,9 +253,7 @@ def _load_pyannote_pipeline() -> object:
             "Install with: pip install \"mlx-qwen3-asr[diarize]\""
         ) from exc
 
-    kwargs: dict[str, Any] = {}
-    if token:
-        kwargs["use_auth_token"] = token
+    kwargs = _pyannote_auth_kwargs(Pipeline.from_pretrained, token)
     try:
         pipeline = Pipeline.from_pretrained(model_id, **kwargs)
     except Exception as exc:
@@ -274,10 +261,26 @@ def _load_pyannote_pipeline() -> object:
             f"Failed to initialize pyannote pipeline '{model_id}'. "
             "If this model is gated, accept its Hugging Face terms and set "
             "PYANNOTE_AUTH_TOKEN (or HF_TOKEN). You can also override "
-            "PYANNOTE_MODEL_ID."
+            "PYANNOTE_MODEL_ID. "
+            f"Root cause: {_format_exception(exc)}"
         ) from exc
     _PYANNOTE_PIPELINE_CACHE[key] = pipeline
     return pipeline
+
+
+def _pyannote_auth_kwargs(from_pretrained: Any, token: str) -> dict[str, Any]:
+    """Build auth kwargs for pyannote 4 while tolerating pyannote 3-style APIs."""
+    if not token:
+        return {}
+    try:
+        params = signature(from_pretrained).parameters
+    except (TypeError, ValueError):
+        return {"token": token}
+    if "token" in params:
+        return {"token": token}
+    if "use_auth_token" in params:
+        return {"use_auth_token": token}
+    return {}
 
 
 def _pyannote_input(audio_np: np.ndarray, sr: int) -> dict[str, Any]:
@@ -319,11 +322,43 @@ def _speaker_count_kwargs(config: DiarizationConfig) -> dict[str, int]:
     }
 
 
+def _diarization_runtime_error(exc: Exception) -> RuntimeError:
+    return RuntimeError(
+        "pyannote diarization inference failed. "
+        "Verify the installed '[diarize]' extra and any required Hugging Face "
+        "token/terms for your diarization model. "
+        f"Root cause: {_format_exception(exc)}"
+    )
+
+
+def _format_exception(exc: Exception) -> str:
+    msg = str(exc).strip()
+    if msg:
+        return f"{type(exc).__name__}: {msg}"
+    return type(exc).__name__
+
+
+def _select_pyannote_annotation(output: Any) -> Any:
+    """Return the annotation object from pyannote 4 DiarizeOutput or legacy output."""
+    # Community-1 exposes exclusive diarization specifically to simplify
+    # reconciliation with transcription timestamps, which matches this module's
+    # single-speaker attribution contract.
+    exclusive = getattr(output, "exclusive_speaker_diarization", None)
+    if exclusive is not None:
+        return exclusive
+    regular = getattr(output, "speaker_diarization", None)
+    if regular is not None:
+        return regular
+    return output
+
+
 def _annotation_to_turns(annotation: Any, *, duration: float) -> list[dict]:
     raw: list[tuple[str, float, float]] = []
 
     if annotation is None:
         return []
+
+    annotation = _select_pyannote_annotation(annotation)
 
     if hasattr(annotation, "itertracks"):
         for segment, _, label in annotation.itertracks(yield_label=True):

--- a/mlx_qwen3_asr/diarization.py
+++ b/mlx_qwen3_asr/diarization.py
@@ -257,15 +257,25 @@ def _load_pyannote_pipeline() -> object:
     try:
         pipeline = Pipeline.from_pretrained(model_id, **kwargs)
     except Exception as exc:
-        raise RuntimeError(
-            f"Failed to initialize pyannote pipeline '{model_id}'. "
-            "If this model is gated, accept its Hugging Face terms and set "
-            "PYANNOTE_AUTH_TOKEN (or HF_TOKEN). You can also override "
-            "PYANNOTE_MODEL_ID. "
-            f"Root cause: {_format_exception(exc)}"
-        ) from exc
+        raise _pyannote_pipeline_init_error(model_id, _format_exception(exc)) from exc
+    if pipeline is None:
+        raise _pyannote_pipeline_init_error(
+            model_id,
+            "Pipeline.from_pretrained returned None; pyannote could not download "
+            "or load the pipeline configuration.",
+        )
     _PYANNOTE_PIPELINE_CACHE[key] = pipeline
     return pipeline
+
+
+def _pyannote_pipeline_init_error(model_id: str, root_cause: str) -> RuntimeError:
+    return RuntimeError(
+        f"Failed to initialize pyannote pipeline '{model_id}'. "
+        "If this model is gated, accept its Hugging Face terms and set "
+        "PYANNOTE_AUTH_TOKEN (or HF_TOKEN). You can also override "
+        "PYANNOTE_MODEL_ID. "
+        f"Root cause: {root_cause}"
+    )
 
 
 def _pyannote_auth_kwargs(from_pretrained: Any, token: str) -> dict[str, Any]:

--- a/mlx_qwen3_asr/diarization.py
+++ b/mlx_qwen3_asr/diarization.py
@@ -276,11 +276,10 @@ def _pyannote_auth_kwargs(from_pretrained: Any, token: str) -> dict[str, Any]:
         params = signature(from_pretrained).parameters
     except (TypeError, ValueError):
         return {"token": token}
-    if "token" in params:
-        return {"token": token}
-    if "use_auth_token" in params:
+
+    if "use_auth_token" in params and "token" not in params:
         return {"use_auth_token": token}
-    return {}
+    return {"token": token}
 
 
 def _pyannote_input(audio_np: np.ndarray, sr: int) -> dict[str, Any]:
@@ -338,27 +337,50 @@ def _format_exception(exc: Exception) -> str:
     return type(exc).__name__
 
 
-def _select_pyannote_annotation(output: Any) -> Any:
-    """Return the annotation object from pyannote 4 DiarizeOutput or legacy output."""
+def _pyannote_annotation_candidates(output: Any) -> list[Any]:
+    """Return pyannote 4 annotation candidates in timestamp-attribution order."""
     # Community-1 exposes exclusive diarization specifically to simplify
     # reconciliation with transcription timestamps, which matches this module's
     # single-speaker attribution contract.
+    candidates: list[Any] = []
     exclusive = getattr(output, "exclusive_speaker_diarization", None)
     if exclusive is not None:
-        return exclusive
+        candidates.append(exclusive)
     regular = getattr(output, "speaker_diarization", None)
     if regular is not None:
-        return regular
-    return output
+        candidates.append(regular)
+    candidates.append(output)
+    return candidates
 
 
 def _annotation_to_turns(annotation: Any, *, duration: float) -> list[dict]:
-    raw: list[tuple[str, float, float]] = []
-
     if annotation is None:
         return []
 
-    annotation = _select_pyannote_annotation(annotation)
+    raw: list[tuple[str, float, float]] = []
+    for candidate in _pyannote_annotation_candidates(annotation):
+        raw = _raw_annotation_turns(candidate)
+        if raw:
+            break
+
+    if not raw:
+        return []
+
+    raw.sort(key=lambda x: (x[1], x[2]))
+    label_map: dict[str, str] = {}
+    turns: list[dict] = []
+
+    for label, start, end in raw:
+        if label not in label_map:
+            label_map[label] = f"SPEAKER_{len(label_map):02d}"
+        speaker = label_map[label]
+        turns.append({"speaker": speaker, "start": max(0.0, start), "end": min(duration, end)})
+
+    return _merge_speaker_turns(turns)
+
+
+def _raw_annotation_turns(annotation: Any) -> list[tuple[str, float, float]]:
+    raw: list[tuple[str, float, float]] = []
 
     if hasattr(annotation, "itertracks"):
         for segment, _, label in annotation.itertracks(yield_label=True):
@@ -376,20 +398,7 @@ def _annotation_to_turns(annotation: Any, *, duration: float) -> list[dict]:
             if end > start:
                 raw.append((label, start, end))
 
-    if not raw:
-        return []
-
-    raw.sort(key=lambda x: (x[1], x[2]))
-    label_map: dict[str, str] = {}
-    turns: list[dict] = []
-
-    for label, start, end in raw:
-        if label not in label_map:
-            label_map[label] = f"SPEAKER_{len(label_map):02d}"
-        speaker = label_map[label]
-        turns.append({"speaker": speaker, "start": max(0.0, start), "end": min(duration, end)})
-
-    return _merge_speaker_turns(turns)
+    return raw
 
 
 def _merge_speaker_turns(turns: list[dict], *, max_gap_sec: float = 0.2) -> list[dict]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 aligner = ["nagisa", "soynlp"]
-diarize = ["pyannote.audio>=3.3.2"]
+diarize = ["pyannote.audio>=4.0.4,<5"]
 mic = ["sounddevice>=0.4.6"]
 serve = ["fastapi>=0.100.0", "uvicorn>=0.20.0", "python-multipart>=0.0.5"]
 dev = ["pytest", "ruff", "mypy"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -478,7 +478,7 @@ def test_cli_diarize_preflight_emits_token_hint(monkeypatch, capsys):
     monkeypatch.setattr(cli, "_ensure_diarization_backend_ready", lambda: None)
 
     cli._preflight_diarization_runtime()  # noqa: SLF001
-    assert "may require Hugging Face auth" in capsys.readouterr().err
+    assert "default pyannote/speaker-diarization-community-1" in capsys.readouterr().err
 
 
 def test_cli_diarize_preflight_checks_backend_readiness(monkeypatch):

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -469,6 +469,32 @@ def test_load_pyannote_pipeline_wraps_from_pretrained_errors(monkeypatch):
         dmod._load_pyannote_pipeline()  # noqa: SLF001
 
 
+def test_load_pyannote_pipeline_rejects_none_return(monkeypatch):
+    dmod = importlib.import_module("mlx_qwen3_asr.diarization")
+
+    class _FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model_id, *, token=None):  # noqa: ANN001
+            _ = model_id, token
+            return None
+
+    fake_audio_module = types.ModuleType("pyannote.audio")
+    fake_audio_module.Pipeline = _FakePipeline
+    fake_pkg = types.ModuleType("pyannote")
+    fake_pkg.audio = fake_audio_module
+
+    monkeypatch.setitem(sys.modules, "pyannote", fake_pkg)
+    monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
+    monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Root cause: Pipeline\.from_pretrained returned None",
+    ):
+        dmod._load_pyannote_pipeline()  # noqa: SLF001
+
+
 def test_diarize_word_segments_adds_speaker_labels():
     cfg = validate_diarization_config(
         num_speakers=None,

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from mlx_qwen3_asr.diarization import (
+    DEFAULT_PYANNOTE_MODEL_ID,
     DEFAULT_SPEAKER_LABEL,
     build_speaker_segments_from_turns,
     diarize_chunk_items,
@@ -43,6 +44,12 @@ class _RecordingPipeline:
     def __call__(self, payload, **kwargs):  # noqa: ANN001
         self.calls.append((payload, kwargs))
         return self.annotation
+
+
+class _FakeDiarizeOutput:
+    def __init__(self, *, speaker_diarization, exclusive_speaker_diarization=None):
+        self.speaker_diarization = speaker_diarization
+        self.exclusive_speaker_diarization = exclusive_speaker_diarization
 
 
 def test_validate_diarization_config_rejects_invalid_bounds():
@@ -148,6 +155,62 @@ def test_infer_speaker_turns_merges_adjacent_same_speaker(monkeypatch):
     assert turns == [{"speaker": "SPEAKER_00", "start": 0.0, "end": 0.8}]
 
 
+def test_infer_speaker_turns_unwraps_pyannote4_exclusive_diarization(monkeypatch):
+    dmod = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(
+        dmod,
+        "_pyannote_input",
+        lambda audio, sr: {"waveform": audio[None, :], "sample_rate": sr},
+    )
+
+    audio = np.zeros((16000,), dtype=np.float32)
+    cfg = validate_diarization_config(
+        num_speakers=None,
+        min_speakers=1,
+        max_speakers=2,
+    )
+    regular = _FakeAnnotation([(0.0, 1.0, "regular")])
+    exclusive = _FakeAnnotation([(0.0, 0.5, "exclusive-a"), (0.5, 1.0, "exclusive-b")])
+    pipe = _RecordingPipeline(
+        _FakeDiarizeOutput(
+            speaker_diarization=regular,
+            exclusive_speaker_diarization=exclusive,
+        )
+    )
+
+    turns = infer_speaker_turns(audio, sr=16000, config=cfg, _pipeline=pipe)
+
+    assert turns == [
+        {"speaker": "SPEAKER_00", "start": 0.0, "end": 0.5},
+        {"speaker": "SPEAKER_01", "start": 0.5, "end": 1.0},
+    ]
+
+
+def test_infer_speaker_turns_unwraps_pyannote4_regular_diarization(monkeypatch):
+    dmod = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(
+        dmod,
+        "_pyannote_input",
+        lambda audio, sr: {"waveform": audio[None, :], "sample_rate": sr},
+    )
+
+    audio = np.zeros((16000,), dtype=np.float32)
+    cfg = validate_diarization_config(
+        num_speakers=None,
+        min_speakers=1,
+        max_speakers=2,
+    )
+    pipe = _RecordingPipeline(
+        _FakeDiarizeOutput(
+            speaker_diarization=_FakeAnnotation([(0.0, 1.0, "regular")]),
+        )
+    )
+
+    turns = infer_speaker_turns(audio, sr=16000, config=cfg, _pipeline=pipe)
+
+    assert turns == [{"speaker": "SPEAKER_00", "start": 0.0, "end": 1.0}]
+
+
 def test_infer_speaker_turns_raises_helpful_error_when_dependency_missing(monkeypatch):
     dmod = importlib.import_module("mlx_qwen3_asr.diarization")
 
@@ -185,7 +248,7 @@ def test_infer_speaker_turns_wraps_pipeline_runtime_errors(monkeypatch):
         max_speakers=2,
     )
 
-    with pytest.raises(RuntimeError, match="pyannote diarization inference failed"):
+    with pytest.raises(RuntimeError, match="Root cause: RuntimeError: backend exploded"):
         infer_speaker_turns(
             np.zeros((8000,), dtype=np.float32),
             sr=8000,
@@ -257,7 +320,7 @@ def test_infer_speaker_turns_does_not_retry_on_non_kwargs_type_error(monkeypatch
     )
     pipe = _TypeErrorPipeline()
 
-    with pytest.raises(RuntimeError, match="pyannote diarization inference failed"):
+    with pytest.raises(RuntimeError, match="Root cause: TypeError: shape mismatch"):
         infer_speaker_turns(
             np.zeros((8000,), dtype=np.float32),
             sr=8000,
@@ -267,13 +330,73 @@ def test_infer_speaker_turns_does_not_retry_on_non_kwargs_type_error(monkeypatch
     assert pipe.calls == 1
 
 
+def test_load_pyannote_pipeline_uses_pyannote4_token_kwarg(monkeypatch):
+    dmod = importlib.import_module("mlx_qwen3_asr.diarization")
+    calls = {}
+
+    class _FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model_id, *, token=None):  # noqa: ANN001
+            calls["model_id"] = model_id
+            calls["token"] = token
+            return object()
+
+    fake_audio_module = types.ModuleType("pyannote.audio")
+    fake_audio_module.Pipeline = _FakePipeline
+    fake_pkg = types.ModuleType("pyannote")
+    fake_pkg.audio = fake_audio_module
+
+    monkeypatch.setitem(sys.modules, "pyannote", fake_pkg)
+    monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
+    monkeypatch.setenv("PYANNOTE_AUTH_TOKEN", "hf_test")
+    monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
+
+    dmod._load_pyannote_pipeline()  # noqa: SLF001
+
+    assert calls == {
+        "model_id": DEFAULT_PYANNOTE_MODEL_ID,
+        "token": "hf_test",
+    }
+
+
+def test_load_pyannote_pipeline_falls_back_to_pyannote3_auth_kwarg(monkeypatch):
+    dmod = importlib.import_module("mlx_qwen3_asr.diarization")
+    calls = {}
+
+    class _FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model_id, *, use_auth_token=None):  # noqa: ANN001
+            calls["model_id"] = model_id
+            calls["use_auth_token"] = use_auth_token
+            return object()
+
+    fake_audio_module = types.ModuleType("pyannote.audio")
+    fake_audio_module.Pipeline = _FakePipeline
+    fake_pkg = types.ModuleType("pyannote")
+    fake_pkg.audio = fake_audio_module
+
+    monkeypatch.setitem(sys.modules, "pyannote", fake_pkg)
+    monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
+    monkeypatch.setenv("PYANNOTE_AUTH_TOKEN", "hf_test")
+    monkeypatch.setenv("PYANNOTE_MODEL_ID", "pyannote/speaker-diarization-3.1")
+    dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
+
+    dmod._load_pyannote_pipeline()  # noqa: SLF001
+
+    assert calls == {
+        "model_id": "pyannote/speaker-diarization-3.1",
+        "use_auth_token": "hf_test",
+    }
+
+
 def test_load_pyannote_pipeline_wraps_from_pretrained_errors(monkeypatch):
     dmod = importlib.import_module("mlx_qwen3_asr.diarization")
 
     class _FakePipeline:
         @classmethod
-        def from_pretrained(cls, model_id, **kwargs):  # noqa: ANN001
-            _ = model_id, kwargs
+        def from_pretrained(cls, model_id, *, token=None):  # noqa: ANN001
+            _ = model_id, token
             raise RuntimeError("401 unauthorized")
 
     fake_audio_module = types.ModuleType("pyannote.audio")
@@ -283,10 +406,10 @@ def test_load_pyannote_pipeline_wraps_from_pretrained_errors(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "pyannote", fake_pkg)
     monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
-    monkeypatch.setenv("PYANNOTE_MODEL_ID", "pyannote/speaker-diarization-3.1")
+    monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
-    with pytest.raises(RuntimeError, match="Failed to initialize pyannote pipeline"):
+    with pytest.raises(RuntimeError, match="Root cause: RuntimeError: 401 unauthorized"):
         dmod._load_pyannote_pipeline()  # noqa: SLF001
 
 

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -211,6 +211,32 @@ def test_infer_speaker_turns_unwraps_pyannote4_regular_diarization(monkeypatch):
     assert turns == [{"speaker": "SPEAKER_00", "start": 0.0, "end": 1.0}]
 
 
+def test_infer_speaker_turns_falls_back_when_pyannote4_exclusive_is_empty(monkeypatch):
+    dmod = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(
+        dmod,
+        "_pyannote_input",
+        lambda audio, sr: {"waveform": audio[None, :], "sample_rate": sr},
+    )
+
+    audio = np.zeros((16000,), dtype=np.float32)
+    cfg = validate_diarization_config(
+        num_speakers=None,
+        min_speakers=1,
+        max_speakers=2,
+    )
+    pipe = _RecordingPipeline(
+        _FakeDiarizeOutput(
+            speaker_diarization=_FakeAnnotation([(0.0, 1.0, "regular")]),
+            exclusive_speaker_diarization=_FakeAnnotation([]),
+        )
+    )
+
+    turns = infer_speaker_turns(audio, sr=16000, config=cfg, _pipeline=pipe)
+
+    assert turns == [{"speaker": "SPEAKER_00", "start": 0.0, "end": 1.0}]
+
+
 def test_infer_speaker_turns_raises_helpful_error_when_dependency_missing(monkeypatch):
     dmod = importlib.import_module("mlx_qwen3_asr.diarization")
 
@@ -357,6 +383,36 @@ def test_load_pyannote_pipeline_uses_pyannote4_token_kwarg(monkeypatch):
     assert calls == {
         "model_id": DEFAULT_PYANNOTE_MODEL_ID,
         "token": "hf_test",
+    }
+
+
+def test_load_pyannote_pipeline_defaults_to_token_for_kwargs_signature(monkeypatch):
+    dmod = importlib.import_module("mlx_qwen3_asr.diarization")
+    calls = {}
+
+    class _FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model_id, **kwargs):  # noqa: ANN001
+            calls["model_id"] = model_id
+            calls["kwargs"] = kwargs
+            return object()
+
+    fake_audio_module = types.ModuleType("pyannote.audio")
+    fake_audio_module.Pipeline = _FakePipeline
+    fake_pkg = types.ModuleType("pyannote")
+    fake_pkg.audio = fake_audio_module
+
+    monkeypatch.setitem(sys.modules, "pyannote", fake_pkg)
+    monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
+    monkeypatch.setenv("PYANNOTE_AUTH_TOKEN", "hf_test")
+    monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
+
+    dmod._load_pyannote_pipeline()  # noqa: SLF001
+
+    assert calls == {
+        "model_id": DEFAULT_PYANNOTE_MODEL_ID,
+        "kwargs": {"token": "hf_test"},
     }
 
 


### PR DESCRIPTION
## Summary

Fixes #7 by making pyannote.audio 4.x the supported optional diarization backend for `[diarize]`. Fresh installs now resolve to runtime code that matches the current pyannote auth, model, and output contracts instead of pyannote 3-era behavior.

Core ASR remains MLX-native and torch-free unless users opt into `[diarize]`.

## Root Cause

Issue #7 showed that `[diarize]` allowed pyannote 4 installs through `pyannote.audio>=3.3.2`, while the runtime still assumed pyannote 3 contracts: `use_auth_token`, direct `Annotation` output, and `speaker-diarization-3.1`. That broke the documented fresh-install path and hid actionable dependency/API failures behind confusing gated-model errors.

## Flow

```text
mlx-qwen3-asr --diarize
        |
        v
load pyannote.audio 4 pipeline
        |
        |  token=PYANNOTE_AUTH_TOKEN / HF_TOKEN
        v
pyannote/speaker-diarization-community-1
        |
        v
DiarizeOutput
        |
        |-- exclusive_speaker_diarization  (preferred)
        |-- speaker_diarization            (fallback)
        `-- direct Annotation/list          (legacy/local fallback)
        |
        v
speaker turns -> ASR word/chunk speaker attribution
```

## What Changed

- Pins the optional diarization extra to `pyannote.audio>=4.0.4,<5`.
- Switches the default model to `pyannote/speaker-diarization-community-1`.
- Uses modern `token=` auth, with a legacy-only `use_auth_token=` fallback.
- Rejects `Pipeline.from_pretrained(...) is None` as an initialization failure with a clear root cause.
- Handles pyannote 4 `DiarizeOutput`, preferring exclusive diarization while falling back safely.
- Updates CLI doctor/preflight messages, README setup/troubleshooting, and decision history.
- Adds regression coverage for auth kwargs, output unwrapping, empty exclusive output, root-cause errors, and failed pipeline loads.

## Validation

- `uv pip compile pyproject.toml --extra diarize --python-platform aarch64-apple-darwin --python-version 3.13` resolves `pyannote-audio==4.0.4`, `torchaudio==2.11.0`, `torchcodec==0.11.1`.
- `.venv/bin/python -m pytest tests/test_diarization.py tests/test_cli.py -q` -> 43 passed.
- `.venv/bin/python -m pytest tests/ -q` -> 567 passed, 2 skipped.
- `.venv/bin/ruff check mlx_qwen3_asr tests/test_diarization.py tests/test_cli.py` -> pass.
- `.venv/bin/python scripts/quality_gate.py --mode fast` -> pass.
- Live local integration: `RUN_DIARIZATION_LIVE_INTEGRATION=1 .venv/bin/python -m pytest -q tests/test_diarization_live_integration.py` -> 1 passed.
- GitHub Actions run `24946715422`: `lint`, `test`, and `diarization-integration` all passed.
