### PR TITLE
fix: release GPU memory between chunks to prevent unbounded growth

### DIFF
--- a/mlx_qwen3_asr/transcribe.py
+++ b/mlx_qwen3_asr/transcribe.py
@@ -808,6 +808,13 @@ def _transcribe_loaded_components(
             },
         )
 
+        # Release large per-chunk GPU tensors so the Metal allocator can reclaim
+        # memory before the next chunk.  Without this, processing hour-long audio
+        # causes unbounded memory growth (~90 GiB observed).
+        del mel, feature_lens, audio_features, input_ids, position_ids
+        del generation_output, generation, draft_audio_features
+        mx.clear_cache()
+
     final_language = canonicalize_language(detected_language) or detected_language
     out_segments: Optional[list[dict]] = all_segments if return_timestamps else None
     speaker_segments: Optional[list[dict]] = None

--- a/mlx_qwen3_asr/transcribe.py
+++ b/mlx_qwen3_asr/transcribe.py
@@ -811,7 +811,7 @@ def _transcribe_loaded_components(
         # Release large per-chunk GPU tensors so the Metal allocator can reclaim
         # memory before the next chunk.  Without this, processing hour-long audio
         # causes unbounded memory growth (~90 GiB observed).
-        del mel, feature_lens, audio_features, input_ids, position_ids
+        del mel, feature_lens, audio_features, input_ids, positions, position_ids
         del generation_output, generation, draft_audio_features
         mx.clear_cache()
 

--- a/mlx_qwen3_asr/transcribe.py
+++ b/mlx_qwen3_asr/transcribe.py
@@ -118,6 +118,19 @@ def _join_chunk_texts(texts: list[str], language: str) -> str:
     return joiner.join(texts)
 
 
+def _clear_mlx_cache() -> None:
+    """Release cached MLX buffers across old and new MLX API spellings."""
+    clear_cache = getattr(mx, "clear_cache", None)
+    if callable(clear_cache):
+        clear_cache()
+        return
+
+    metal = getattr(mx, "metal", None)
+    metal_clear_cache = getattr(metal, "clear_cache", None)
+    if callable(metal_clear_cache):
+        metal_clear_cache()
+
+
 def _build_transcribe_options(
     *,
     context: str = "",
@@ -813,7 +826,7 @@ def _transcribe_loaded_components(
         # causes unbounded memory growth (~90 GiB observed).
         del mel, feature_lens, audio_features, input_ids, positions, position_ids
         del generation_output, generation, draft_audio_features
-        mx.clear_cache()
+        _clear_mlx_cache()
 
     final_language = canonicalize_language(detected_language) or detected_language
     out_segments: Optional[list[dict]] = all_segments if return_timestamps else None

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -179,6 +179,32 @@ def test_coerce_generation_result_prefers_length_when_legacy_output_hits_cap():
     assert result.truncated is True
 
 
+def test_clear_mlx_cache_uses_core_api(monkeypatch):
+    tmod = importlib.import_module("mlx_qwen3_asr.transcribe")
+    calls = []
+
+    fake_mx = SimpleNamespace(clear_cache=lambda: calls.append("core"))
+    monkeypatch.setattr(tmod, "mx", fake_mx)
+
+    tmod._clear_mlx_cache()
+
+    assert calls == ["core"]
+
+
+def test_clear_mlx_cache_falls_back_to_metal_api(monkeypatch):
+    tmod = importlib.import_module("mlx_qwen3_asr.transcribe")
+    calls = []
+
+    fake_mx = SimpleNamespace(
+        metal=SimpleNamespace(clear_cache=lambda: calls.append("metal"))
+    )
+    monkeypatch.setattr(tmod, "mx", fake_mx)
+
+    tmod._clear_mlx_cache()
+
+    assert calls == ["metal"]
+
+
 @pytest.mark.parametrize(
     "reasons,expected",
     [


### PR DESCRIPTION
## Summary

- Fix unbounded memory growth (~90 GiB observed) when transcribing hour-long audio files
- Add explicit `del` of per-chunk GPU tensors + `mx.clear_cache()` at chunk boundaries in `_transcribe_loaded_components`

## Problem

When processing long audio (e.g. 108 minutes → 345 chunks), the chunked transcription loop in `_transcribe_loaded_components` creates large MLX arrays each iteration (mel spectrogram, audio features, KV cache via `generate_with_info`, position IDs) but never explicitly releases them. Combined with MLX's Metal memory pool retaining freed buffers, this causes memory to grow linearly with chunk count.

## Root Cause

1. No `del` of large intermediate tensors between chunks — Python objects survive until the next iteration's reassignment (or longer if referenced by the computation graph)
2. No `mx.clear_cache()` — the Metal allocator pools freed buffers indefinitely without this call

## Fix

3 lines at the end of the chunk loop body:

```python
del mel, feature_lens, audio_features, input_ids, position_ids
del generation_output, generation, draft_audio_features
mx.clear_cache()
```

## Verification

Tested on a 108-minute AAC file (345 chunks):

| Metric | Before | After |
|--------|--------|-------|
| Peak memory | ~90 GiB | **3.79 GiB** |
| Active memory at end | unbounded | **1.81 GiB** |
| Cache memory at end | accumulated | **0.00 GiB** |

Processing completed successfully in 510s with correct transcription output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory handling during long transcription sessions to reduce memory growth and improve stability across consecutive chunks.

* **Documentation**
  * Added a memory-events note describing cache-cleanup compatibility guidance and validation recommendations for MLX API usage.

* **Tests**
  * Added unit tests verifying cache-cleanup behavior across different MLX API variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moona3k/mlx-qwen3-asr/pull/11)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->