### PR TITLE
[codex] Fix mlx-community checkpoint loading

### DIFF
--- a/docs/memory/events/2026-05.md
+++ b/docs/memory/events/2026-05.md
@@ -1,0 +1,35 @@
+# Memory Events: 2026-05
+
+Append-only implementation events. Do not rewrite old entries for content
+changes; append a new event instead.
+
+## MEM-2026-05-15-001
+
+- Date: 2026-05-15
+- Scope: Validated and fixed GitHub issues #12 and #13 for `mlx-community`
+  Qwen3-ASR checkpoint loading.
+- Decision:
+  - Treat `mlx-community` checkpoints as authoritative MLX checkpoint layouts:
+    materialize missing tied `lm_head` tensors from `model.embed_tokens`, and
+    quantize only module paths with saved `.scales` tensors instead of
+    quantizing the whole model.
+- Reuse next time:
+  - For external checkpoint compatibility, verify both config/index metadata
+    and a real public artifact load. If quantization is partial, derive the
+    quantized module predicate from saved tensor keys rather than assuming a
+    model-wide quantization policy.
+- Evidence:
+  - GitHub issues #12 and #13
+  - `mlx_qwen3_asr/load_models.py`
+  - `tests/test_load_models.py`
+  - Hugging Face metadata for `mlx-community/Qwen3-ASR-0.6B-bf16`,
+    `mlx-community/Qwen3-ASR-0.6B-4bit`,
+    `mlx-community/Qwen3-ASR-1.7B-bf16`, and
+    `mlx-community/Qwen3-ASR-1.7B-8bit`
+  - Real load smokes: `mlx-community/Qwen3-ASR-0.6B-bf16`,
+    `mlx-community/Qwen3-ASR-0.6B-4bit`, and
+    `mlx-community/Qwen3-ASR-0.6B-8bit`
+  - `uv run pytest tests/test_load_models.py -q`
+  - `uv run ruff check mlx_qwen3_asr tests`
+  - `uv run pytest tests/ -q`
+  - `uv run python scripts/quality_gate.py --mode fast`

--- a/docs/memory/events/2026-05.md
+++ b/docs/memory/events/2026-05.md
@@ -33,3 +33,23 @@ changes; append a new event instead.
   - `uv run ruff check mlx_qwen3_asr tests`
   - `uv run pytest tests/ -q`
   - `uv run python scripts/quality_gate.py --mode fast`
+
+## MEM-2026-05-15-002
+
+- Date: 2026-05-15
+- Scope: Addressed PR #14 review comments on tied LM-head auxiliary tensors
+  and helper docstring coverage.
+- Decision:
+  - Materialize missing `lm_head.scales` / `lm_head.biases` even when
+    `lm_head.weight` is already present, but only when the existing LM-head
+    weight shape matches `model.embed_tokens.weight`. Keep selective
+    quantization keyed to standard MLX `.scales` tensors.
+- Reuse next time:
+  - For tied quantized checkpoint compatibility, separate weight presence from
+    auxiliary tensor presence and avoid copying quantization metadata onto a
+    shape-mismatched explicit projection.
+- Evidence:
+  - Gemini Code Assist comments on PR #14
+  - CodeRabbit docstring coverage warning on PR #14
+  - `mlx_qwen3_asr/load_models.py`
+  - `tests/test_load_models.py`

--- a/mlx_qwen3_asr/load_models.py
+++ b/mlx_qwen3_asr/load_models.py
@@ -115,6 +115,7 @@ def _load_model_with_resolved_path(
     # Load weights
     weights = _load_safetensors(model_path)
     weights = remap_weights(weights)
+    weights = _materialize_tied_lm_head_weights(weights, config)
 
     # Instantiate model
     model = Qwen3ASRModel(config)
@@ -127,7 +128,7 @@ def _load_model_with_resolved_path(
             group_size = int(quant_cfg.get("group_size", 64))
         else:
             bits, group_size = _infer_quantization_params(weights, model)
-        nn.quantize(model, bits=bits, group_size=group_size)
+        _quantize_model_for_loaded_weights(model, weights, bits=bits, group_size=group_size)
 
     # Load weights into model
     model.load_weights(list(weights.items()))
@@ -157,6 +158,55 @@ def _cast_tree_dtype(tree: dict, dtype: mx.Dtype) -> dict:
         if isinstance(x, mx.array) and mx.issubdtype(x.dtype, mx.floating)
         else x,
         tree,
+    )
+
+
+def _model_uses_tied_lm_head(config: Qwen3ASRConfig) -> bool:
+    output_size = config.classify_num or config.text_config.vocab_size
+    return (
+        config.text_config.tie_word_embeddings
+        and output_size == config.text_config.vocab_size
+    )
+
+
+def _materialize_tied_lm_head_weights(
+    weights: dict[str, mx.array],
+    config: Qwen3ASRConfig,
+) -> dict[str, mx.array]:
+    """Fill missing LM-head tensors for checkpoints with tied embeddings."""
+    if not _model_uses_tied_lm_head(config):
+        return weights
+    if "lm_head.weight" in weights or "model.embed_tokens.weight" not in weights:
+        return weights
+
+    weights = dict(weights)
+    weights["lm_head.weight"] = weights["model.embed_tokens.weight"]
+    for suffix in (".scales", ".biases"):
+        src = f"model.embed_tokens{suffix}"
+        dst = f"lm_head{suffix}"
+        if src in weights and dst not in weights:
+            weights[dst] = weights[src]
+    return weights
+
+
+def _quantized_module_paths(weights: dict[str, mx.array]) -> set[str]:
+    """Return module paths that have saved MLX quantization parameters."""
+    return {key.removesuffix(".scales") for key in weights if key.endswith(".scales")}
+
+
+def _quantize_model_for_loaded_weights(
+    model: Qwen3ASRModel,
+    weights: dict[str, mx.array],
+    bits: int,
+    group_size: int,
+) -> None:
+    """Quantize only modules that have matching tensors in the checkpoint."""
+    quantized_paths = _quantized_module_paths(weights)
+    nn.quantize(
+        model,
+        bits=bits,
+        group_size=group_size,
+        class_predicate=lambda path, _module: path in quantized_paths,
     )
 
 

--- a/mlx_qwen3_asr/load_models.py
+++ b/mlx_qwen3_asr/load_models.py
@@ -162,6 +162,7 @@ def _cast_tree_dtype(tree: dict, dtype: mx.Dtype) -> dict:
 
 
 def _model_uses_tied_lm_head(config: Qwen3ASRConfig) -> bool:
+    """Return whether the config ties the final projection to token embeddings."""
     output_size = config.classify_num or config.text_config.vocab_size
     return (
         config.text_config.tie_word_embeddings
@@ -176,17 +177,25 @@ def _materialize_tied_lm_head_weights(
     """Fill missing LM-head tensors for checkpoints with tied embeddings."""
     if not _model_uses_tied_lm_head(config):
         return weights
-    if "lm_head.weight" in weights or "model.embed_tokens.weight" not in weights:
+    embedding_weight = weights.get("model.embed_tokens.weight")
+    if embedding_weight is None:
         return weights
 
-    weights = dict(weights)
-    weights["lm_head.weight"] = weights["model.embed_tokens.weight"]
+    lm_head_weight = weights.get("lm_head.weight")
+    can_tie_aux_tensors = lm_head_weight is None or lm_head_weight.shape == embedding_weight.shape
+    materialized = weights
+    if lm_head_weight is None:
+        materialized = dict(weights)
+        materialized["lm_head.weight"] = embedding_weight
+
     for suffix in (".scales", ".biases"):
         src = f"model.embed_tokens{suffix}"
         dst = f"lm_head{suffix}"
-        if src in weights and dst not in weights:
-            weights[dst] = weights[src]
-    return weights
+        if can_tie_aux_tensors and src in materialized and dst not in materialized:
+            if materialized is weights:
+                materialized = dict(weights)
+            materialized[dst] = materialized[src]
+    return materialized
 
 
 def _quantized_module_paths(weights: dict[str, mx.array]) -> set[str]:

--- a/tests/test_load_models.py
+++ b/tests/test_load_models.py
@@ -31,6 +31,7 @@ from mlx_qwen3_asr.model import Qwen3ASRModel
 
 
 def _tiny_config(*, tie_word_embeddings: bool = True) -> Qwen3ASRConfig:
+    """Build a small valid ASR config for loader tests."""
     return Qwen3ASRConfig(
         audio_config=AudioEncoderConfig(
             num_mel_bins=128,
@@ -56,6 +57,7 @@ def _tiny_config(*, tie_word_embeddings: bool = True) -> Qwen3ASRConfig:
 
 
 def _tiny_config_dict(*, tie_word_embeddings: bool = True) -> dict:
+    """Return the nested JSON config shape used by checkpoint directories."""
     return {
         "thinker_config": {
             "audio_config": {
@@ -83,6 +85,7 @@ def _tiny_config_dict(*, tie_word_embeddings: bool = True) -> dict:
 
 
 def _write_tiny_config(model_dir: Path, *, tie_word_embeddings: bool = True) -> None:
+    """Write a tiny nested config.json into a checkpoint fixture directory."""
     (model_dir / "config.json").write_text(
         json.dumps(_tiny_config_dict(tie_word_embeddings=tie_word_embeddings)),
         encoding="utf-8",
@@ -153,6 +156,39 @@ class TestTiedLmHeadWeights:
 
         assert patched is weights
         assert patched["lm_head.weight"] is lm_head
+
+    def test_materializes_missing_aux_tensors_for_explicit_tied_lm_head(self):
+        embedding = mx.zeros((128, 6), dtype=mx.uint32)
+        lm_head = mx.ones((128, 6), dtype=mx.uint32)
+        scales = mx.ones((128, 1), dtype=mx.float16)
+        biases = mx.zeros((128, 1), dtype=mx.float16)
+        weights = {
+            "model.embed_tokens.weight": embedding,
+            "model.embed_tokens.scales": scales,
+            "model.embed_tokens.biases": biases,
+            "lm_head.weight": lm_head,
+        }
+
+        patched = _materialize_tied_lm_head_weights(weights, _tiny_config())
+
+        assert patched["lm_head.weight"] is lm_head
+        assert patched["lm_head.scales"] is scales
+        assert patched["lm_head.biases"] is biases
+
+    def test_does_not_materialize_aux_tensors_for_shape_mismatched_lm_head(self):
+        embedding = mx.zeros((128, 6), dtype=mx.uint32)
+        lm_head = mx.ones((128, 48), dtype=mx.float16)
+        scales = mx.ones((128, 1), dtype=mx.float16)
+        weights = {
+            "model.embed_tokens.weight": embedding,
+            "model.embed_tokens.scales": scales,
+            "lm_head.weight": lm_head,
+        }
+
+        patched = _materialize_tied_lm_head_weights(weights, _tiny_config())
+
+        assert patched is weights
+        assert "lm_head.scales" not in patched
 
     def test_does_not_materialize_when_embeddings_are_not_tied(self):
         embedding = mx.zeros((128, 48), dtype=mx.float16)

--- a/tests/test_load_models.py
+++ b/tests/test_load_models.py
@@ -2,20 +2,91 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import mlx.core as mx
+import mlx.nn as nn
 import mlx.utils as mlx_utils
 
-from mlx_qwen3_asr.config import ACCURACY_MODEL_ID
+from mlx_qwen3_asr.config import (
+    ACCURACY_MODEL_ID,
+    AudioEncoderConfig,
+    Qwen3ASRConfig,
+    TextDecoderConfig,
+)
 from mlx_qwen3_asr.load_models import (
     _cast_tree_dtype,
     _infer_quantization_params,
     _is_quantized_weights,
+    _load_model_with_resolved_path,
+    _materialize_tied_lm_head_weights,
     _ModelHolder,
+    _quantize_model_for_loaded_weights,
+    _quantized_module_paths,
     _read_quantization_config,
     _resolve_path,
 )
+from mlx_qwen3_asr.model import Qwen3ASRModel
+
+
+def _tiny_config(*, tie_word_embeddings: bool = True) -> Qwen3ASRConfig:
+    return Qwen3ASRConfig(
+        audio_config=AudioEncoderConfig(
+            num_mel_bins=128,
+            encoder_layers=1,
+            encoder_attention_heads=2,
+            encoder_ffn_dim=64,
+            d_model=32,
+            output_dim=256,
+            max_source_positions=100,
+            downsample_hidden_size=24,
+        ),
+        text_config=TextDecoderConfig(
+            vocab_size=128,
+            hidden_size=256,
+            intermediate_size=512,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=128,
+            tie_word_embeddings=tie_word_embeddings,
+        ),
+    )
+
+
+def _tiny_config_dict(*, tie_word_embeddings: bool = True) -> dict:
+    return {
+        "thinker_config": {
+            "audio_config": {
+                "num_mel_bins": 128,
+                "encoder_layers": 1,
+                "encoder_attention_heads": 2,
+                "encoder_ffn_dim": 64,
+                "d_model": 32,
+                "output_dim": 256,
+                "max_source_positions": 100,
+                "downsample_hidden_size": 24,
+            },
+            "text_config": {
+                "vocab_size": 128,
+                "hidden_size": 256,
+                "intermediate_size": 512,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "head_dim": 128,
+                "tie_word_embeddings": tie_word_embeddings,
+            },
+        }
+    }
+
+
+def _write_tiny_config(model_dir: Path, *, tie_word_embeddings: bool = True) -> None:
+    (model_dir / "config.json").write_text(
+        json.dumps(_tiny_config_dict(tie_word_embeddings=tie_word_embeddings)),
+        encoding="utf-8",
+    )
 
 
 class TestCastTreeDtype:
@@ -42,6 +113,112 @@ class TestCastTreeDtype:
         assert casted["int_array"].dtype == mx.int32
 
         assert casted["name"] == "keep-me"
+
+
+class TestTiedLmHeadWeights:
+    def test_materializes_missing_tied_lm_head_weight(self):
+        embedding = mx.zeros((128, 48), dtype=mx.float16)
+        weights = {"model.embed_tokens.weight": embedding}
+
+        patched = _materialize_tied_lm_head_weights(weights, _tiny_config())
+
+        assert patched["lm_head.weight"] is embedding
+        assert "lm_head.weight" not in weights
+
+    def test_materializes_quantized_tied_lm_head_aux_tensors(self):
+        embedding = mx.zeros((128, 6), dtype=mx.uint32)
+        scales = mx.ones((128, 1), dtype=mx.float16)
+        biases = mx.zeros((128, 1), dtype=mx.float16)
+        weights = {
+            "model.embed_tokens.weight": embedding,
+            "model.embed_tokens.scales": scales,
+            "model.embed_tokens.biases": biases,
+        }
+
+        patched = _materialize_tied_lm_head_weights(weights, _tiny_config())
+
+        assert patched["lm_head.weight"] is embedding
+        assert patched["lm_head.scales"] is scales
+        assert patched["lm_head.biases"] is biases
+
+    def test_preserves_explicit_lm_head_weight(self):
+        embedding = mx.zeros((128, 48), dtype=mx.float16)
+        lm_head = mx.ones((128, 48), dtype=mx.float16)
+        weights = {
+            "model.embed_tokens.weight": embedding,
+            "lm_head.weight": lm_head,
+        }
+
+        patched = _materialize_tied_lm_head_weights(weights, _tiny_config())
+
+        assert patched is weights
+        assert patched["lm_head.weight"] is lm_head
+
+    def test_does_not_materialize_when_embeddings_are_not_tied(self):
+        embedding = mx.zeros((128, 48), dtype=mx.float16)
+        weights = {"model.embed_tokens.weight": embedding}
+
+        patched = _materialize_tied_lm_head_weights(
+            weights,
+            _tiny_config(tie_word_embeddings=False),
+        )
+
+        assert patched is weights
+        assert "lm_head.weight" not in patched
+
+
+class TestLoadModelWithCommunityLayouts:
+    def test_loads_tied_checkpoint_without_explicit_lm_head(self, tmp_path: Path):
+        model_dir = tmp_path / "tied-bf16"
+        model_dir.mkdir()
+        _write_tiny_config(model_dir)
+
+        model = Qwen3ASRModel(_tiny_config())
+        weights = dict(mlx_utils.tree_flatten(model.parameters()))
+        weights.pop("lm_head.weight")
+        mx.save_safetensors(str(model_dir / "model.safetensors"), weights)
+
+        loaded, _, _ = _load_model_with_resolved_path(str(model_dir), dtype=mx.float16)
+        params = dict(mlx_utils.tree_flatten(loaded.parameters()))
+
+        assert "lm_head.weight" in params
+        assert params["lm_head.weight"].shape == params["model.embed_tokens.weight"].shape
+
+    def test_loads_partially_quantized_checkpoint(self, tmp_path: Path):
+        model_dir = tmp_path / "partial-quant"
+        model_dir.mkdir()
+        _write_tiny_config(model_dir)
+        (model_dir / "quantization_config.json").write_text(
+            '{"bits": 4, "group_size": 64}',
+            encoding="utf-8",
+        )
+
+        model = Qwen3ASRModel(_tiny_config())
+        quantized_paths = {
+            "model.embed_tokens",
+            "model.layers.0.self_attn.q_proj",
+            "lm_head",
+        }
+        nn.quantize(
+            model,
+            bits=4,
+            group_size=64,
+            class_predicate=lambda path, _module: path in quantized_paths,
+        )
+        weights = dict(mlx_utils.tree_flatten(model.parameters()))
+        for key in ("lm_head.weight", "lm_head.scales", "lm_head.biases"):
+            weights.pop(key)
+        mx.save_safetensors(str(model_dir / "model.safetensors"), weights)
+
+        loaded, _, _ = _load_model_with_resolved_path(str(model_dir), dtype=mx.float16)
+        params = dict(mlx_utils.tree_flatten(loaded.parameters()))
+
+        assert "lm_head.scales" in params
+        assert "model.layers.0.self_attn.q_proj.scales" in params
+        assert not any(
+            key.startswith("audio_tower.") and key.endswith((".scales", ".biases"))
+            for key in params
+        )
 
 
 class TestResolvePath:
@@ -229,3 +406,38 @@ class TestQuantizationHelpers:
         cfg = _read_quantization_config(model_dir)
         assert cfg is None
         assert "Failed to parse quantization metadata" in caplog.text
+
+    def test_quantized_module_paths_come_from_saved_scales(self):
+        weights = {
+            "audio_tower.conv_out.weight": mx.zeros((1, 1)),
+            "model.embed_tokens.weight": mx.zeros((1, 1)),
+            "model.embed_tokens.scales": mx.zeros((1, 1)),
+            "model.layers.0.self_attn.q_proj.scales": mx.zeros((1, 1)),
+            "lm_head.scales": mx.zeros((1, 1)),
+        }
+
+        assert _quantized_module_paths(weights) == {
+            "model.embed_tokens",
+            "model.layers.0.self_attn.q_proj",
+            "lm_head",
+        }
+
+    def test_quantize_model_only_converts_modules_with_saved_scales(self):
+        model = Qwen3ASRModel(_tiny_config())
+        weights = {
+            "model.embed_tokens.scales": mx.zeros((1, 1)),
+            "model.layers.0.self_attn.q_proj.scales": mx.zeros((1, 1)),
+            "lm_head.scales": mx.zeros((1, 1)),
+        }
+
+        _quantize_model_for_loaded_weights(model, weights, bits=4, group_size=64)
+        params = dict(mlx_utils.tree_flatten(model.parameters()))
+
+        assert "model.embed_tokens.scales" in params
+        assert "model.layers.0.self_attn.q_proj.scales" in params
+        assert "lm_head.scales" in params
+        assert not any(
+            key.startswith("audio_tower.") and key.endswith((".scales", ".biases"))
+            for key in params
+        )
+        assert "model.layers.0.self_attn.k_proj.scales" not in params


### PR DESCRIPTION
## Summary

Fixes loading for `mlx-community` Qwen3-ASR checkpoints.

These checkpoints use tied `lm_head` and `model.embed_tokens` weights, and the quantized variants only quantize the decoder while keeping the audio encoder full precision. The old loader expected a separate `lm_head.weight` and quantized the whole model, so affected models failed before transcription started.

## What changed

- Fill missing tied `lm_head` tensors from `model.embed_tokens` when the config uses tied embeddings.
- Quantize only module paths that have saved `.scales` tensors in the checkpoint.
- Add regression tests for tied and partially quantized checkpoint layouts.

## Validation

- `uv run pytest tests/test_load_models.py -q`
- `uv run python scripts/quality_gate.py --mode fast`
- Real loader smokes: `mlx-community/Qwen3-ASR-0.6B-bf16`, `4bit`, and `8bit`

Fixes #12.
Fixes #13.
