### PR TITLE
feat: run diarization on the GPU via --diarize-device

### DIFF
--- a/docs/memory/events/2026-08.md
+++ b/docs/memory/events/2026-08.md
@@ -38,3 +38,37 @@
     `mlx_qwen3_asr/cli.py`, `tests/test_diarization.py`
   - Suite: 537 passed / 1 failed vs baseline 525 passed / 1 failed (the single
     failure, `test_audio.py::test_raises_for_too_short_audio`, pre-exists on `main`).
+
+## MEM-2026-08-24-002
+
+- Date: 2026-08-24
+- Scope: Review follow-ups on the diarization device option (PR #17).
+- Decision:
+  - A kwargs dict splatted into several signatures is an implicit contract with
+    no compiler behind it. Guard it structurally: bind the dict produced by
+    `_transcribe_options_to_kwargs` against every consumer signature with
+    `inspect.signature().bind`, rather than writing one narrow regression test
+    per path.
+  - An error path that caches state is as load-bearing as the happy path. After
+    a failed device transfer into a multi-component object, recover it
+    explicitly before reuse; if recovery fails, refuse to cache.
+  - Preflight/warmup must resolve configuration identically to the real run.
+- Reuse next time:
+  - When threading a new option through the package, grep the whole package for
+    an existing sibling option (`diarization_max_speakers`), not the module
+    being edited. `session.py` was a third consumer and was missed that way.
+  - Test doubles must be able to fail selectively. A fake whose `to()` fails for
+    every device cannot distinguish "recovered to CPU" from "never tried".
+  - Keep cache-key assertions hermetic: clear `HF_TOKEN`/`PYANNOTE_*` in tests,
+    otherwise they assert against the developer's environment.
+- What did not work:
+  - Missing `Session.transcribe` broke every async session transcription with
+    `TypeError: got an unexpected keyword argument 'diarization_device'`,
+    including when `diarize=False`. Unit tests did not exercise that path;
+    the signature-binding guard now does.
+- Evidence:
+  - Commits 4fcff7f, f7f0058 on PR #17
+  - `mlx_qwen3_asr/session.py`, `mlx_qwen3_asr/cli.py`,
+    `mlx_qwen3_asr/diarization.py`, `tests/test_transcribe.py`,
+    `tests/test_cli.py`, `tests/test_diarization.py`
+  - Suite 540 passed / 1 failed (pre-existing `test_audio.py` failure on `main`)

--- a/docs/memory/events/2026-08.md
+++ b/docs/memory/events/2026-08.md
@@ -1,0 +1,40 @@
+# Implementation Memory - 2026-08
+
+## MEM-2026-08-24-001
+
+- Date: 2026-08-24
+- Scope: Diarization pipeline ran on CPU regardless of available accelerators.
+- Decision:
+  - Give the pyannote pipeline an explicit device, defaulting to `auto`
+    (MPS, then CUDA, then CPU) and exposed as `--diarize-device`.
+  - Resolve the device *before* the pipeline cache lookup and include it in
+    the cache key. A `(model_id, token)` key silently returns a CPU-resident
+    pipeline to a later MPS caller, which reads as an unreproducible slowdown.
+  - Import `torch` lazily and treat a missing import as "stay on CPU" rather
+    than an error: `cpu` never needs torch, and a missing torch means the
+    `[diarize]` extra is absent, where pyannote's own ImportError is the more
+    actionable message.
+  - Treat `.to(device)` failure as a warning plus CPU fallback, never fatal —
+    a backend operator gap must not cost the user their transcription.
+- Reuse next time:
+  - When adding a device knob to a cached resource, the cache key must include
+    the device, and the resolution must happen before the lookup. Establish the
+    test baseline on a clean checkout first: this branch initially showed 8
+    failures, but `main` already had 1, which isolated the 7 real regressions
+    immediately.
+- What did not work:
+  - Importing `torch` unconditionally at the top of `_load_pyannote_pipeline`
+    hijacked the existing "pyannote missing -> helpful ImportError" path,
+    breaking 5 tests in a dev environment that installs `[dev]` but not
+    `[diarize]`.
+- Evidence:
+  - 265s Chinese/English meeting audio, `pyannote/speaker-diarization-community-1`,
+    `mlx-community/Qwen3-ASR-1.7B-8bit`, M5 Max 128GB:
+    `--diarize-device cpu` 133s vs `--diarize-device mps` 21s (6.3x end-to-end);
+    diarization stage alone 117.5s -> 4.4s (26.7x).
+  - Output is unchanged, not merely similar: 786/786 segments byte-identical
+    across devices (same boundaries, same 8 speaker labels).
+  - `mlx_qwen3_asr/diarization.py`, `mlx_qwen3_asr/transcribe.py`,
+    `mlx_qwen3_asr/cli.py`, `tests/test_diarization.py`
+  - Suite: 537 passed / 1 failed vs baseline 525 passed / 1 failed (the single
+    failure, `test_audio.py::test_raises_for_too_short_audio`, pre-exists on `main`).

--- a/mlx_qwen3_asr/cli.py
+++ b/mlx_qwen3_asr/cli.py
@@ -201,7 +201,15 @@ def _run_doctor() -> int:
     return 0
 
 
-def _preflight_diarization_runtime() -> None:
+def _preflight_diarization_runtime(
+    device: str = DEFAULT_DIARIZATION_DEVICE,
+) -> None:
+    """Fail fast when the diarization backend or model access is unusable.
+
+    Args:
+        device: Device the transcription run will use, so preflight warms the
+            same cache entry instead of a second one.
+    """
     if not _has_module_spec("pyannote.audio"):
         print(
             "Error: --diarize requires optional dependency 'pyannote.audio'.",
@@ -241,19 +249,27 @@ def _preflight_diarization_runtime() -> None:
         )
 
     try:
-        _ensure_diarization_backend_ready()
+        _ensure_diarization_backend_ready(device)
     except (ImportError, RuntimeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
 
 
-def _ensure_diarization_backend_ready() -> None:
-    """Validate diarization backend/model access before transcription starts."""
+def _ensure_diarization_backend_ready(
+    device: str = DEFAULT_DIARIZATION_DEVICE,
+) -> None:
+    """Validate diarization backend/model access before transcription starts.
+
+    Args:
+        device: Device the transcription run will use. Preflight must warm the
+            same device, otherwise the cached pipeline is keyed to a different
+            one and transcription pays for a second load.
+    """
     # Intentional private import: we want to fail fast before spending time
     # on ASR transcription when diarization backend access is invalid.
     from .diarization import _load_pyannote_pipeline
 
-    _load_pyannote_pipeline()
+    _load_pyannote_pipeline(device=device)
 
 
 def _emit_new_stable_text(
@@ -633,7 +649,7 @@ def main():
         )
         raise SystemExit(1)
     if args.diarize and not args.streaming and not args.mic:
-        _preflight_diarization_runtime()
+        _preflight_diarization_runtime(args.diarize_device)
 
     # Lazy imports for faster --help
     import mlx.core as mx

--- a/mlx_qwen3_asr/cli.py
+++ b/mlx_qwen3_asr/cli.py
@@ -14,6 +14,10 @@ from typing import Optional
 
 from ._version import __version__
 from .config import DEFAULT_MODEL_ID
+from .diarization import (
+    DEFAULT_DIARIZATION_DEVICE,
+    SUPPORTED_DIARIZATION_DEVICES,
+)
 
 _FFMPEG_REQUIRED_SUFFIXES = {
     ".aac",
@@ -412,6 +416,15 @@ def main():
         type=int,
         default=8,
         help="Maximum speaker count for --diarize auto mode (default: 8).",
+    )
+    parser.add_argument(
+        "--diarize-device",
+        choices=SUPPORTED_DIARIZATION_DEVICES,
+        default=DEFAULT_DIARIZATION_DEVICE,
+        help=(
+            "Device for the pyannote diarization pipeline "
+            "(default: auto -> mps/cuda when available, else cpu)."
+        ),
     )
     parser.add_argument(
         "--forced-aligner",
@@ -819,6 +832,7 @@ def main():
                     diarization_num_speakers=args.num_speakers,
                     diarization_min_speakers=args.min_speakers,
                     diarization_max_speakers=args.max_speakers,
+                    diarization_device=args.diarize_device,
                     return_chunks=True,
                     forced_aligner=aligner,
                     dtype=dtype,

--- a/mlx_qwen3_asr/diarization.py
+++ b/mlx_qwen3_asr/diarization.py
@@ -16,6 +16,8 @@ import numpy as np
 
 DEFAULT_SPEAKER_LABEL = "SPEAKER_00"
 DEFAULT_PYANNOTE_MODEL_ID = "pyannote/speaker-diarization-community-1"
+DEFAULT_DIARIZATION_DEVICE = "auto"
+SUPPORTED_DIARIZATION_DEVICES = ("auto", "cpu", "mps", "cuda")
 
 
 @dataclass(frozen=True)
@@ -25,6 +27,7 @@ class DiarizationConfig:
     num_speakers: Optional[int] = None
     min_speakers: int = 1
     max_speakers: int = 8
+    device: str = DEFAULT_DIARIZATION_DEVICE
 
 
 def validate_diarization_config(
@@ -32,6 +35,7 @@ def validate_diarization_config(
     num_speakers: Optional[int],
     min_speakers: int,
     max_speakers: int,
+    device: str = DEFAULT_DIARIZATION_DEVICE,
 ) -> DiarizationConfig:
     """Validate diarization configuration values."""
     if num_speakers is not None and num_speakers < 1:
@@ -42,10 +46,16 @@ def validate_diarization_config(
         raise ValueError(
             "diarization_max_speakers must be >= diarization_min_speakers."
         )
+    if device not in SUPPORTED_DIARIZATION_DEVICES:
+        raise ValueError(
+            "diarization_device must be one of "
+            f"{', '.join(SUPPORTED_DIARIZATION_DEVICES)}; got {device!r}."
+        )
     return DiarizationConfig(
         num_speakers=num_speakers,
         min_speakers=min_speakers,
         max_speakers=max_speakers,
+        device=device,
     )
 
 
@@ -62,7 +72,7 @@ def infer_speaker_turns(
     if audio.size == 0:
         return []
 
-    pipeline = _pipeline or _load_pyannote_pipeline()
+    pipeline = _pipeline or _load_pyannote_pipeline(device=config.device)
     kwargs = _speaker_count_kwargs(config)
     audio_np = np.asarray(audio, dtype=np.float32).reshape(-1)
 
@@ -229,10 +239,56 @@ def diarize_chunk_items(
     return _merge_speaker_segments(items)
 
 
-_PYANNOTE_PIPELINE_CACHE: dict[tuple[str, str], object] = {}
+_PYANNOTE_PIPELINE_CACHE: dict[tuple[str, str, str], object] = {}
 
 
-def _load_pyannote_pipeline() -> object:
+def _resolve_diarization_device(requested: str, torch_module: Any) -> str:
+    """Resolve ``auto`` to the fastest backend torch reports as available.
+
+    Args:
+        requested: One of ``SUPPORTED_DIARIZATION_DEVICES``.
+        torch_module: The imported ``torch`` module (injected for testability).
+
+    Returns:
+        A concrete device string: ``mps``, ``cuda``, or ``cpu``.
+    """
+    if requested != "auto":
+        return requested
+    backends = getattr(torch_module, "backends", None)
+    mps = getattr(backends, "mps", None)
+    if mps is not None and mps.is_available():
+        return "mps"
+    cuda = getattr(torch_module, "cuda", None)
+    if cuda is not None and cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def _resolve_torch_device(device: str) -> tuple[Any, str]:
+    """Import torch only when a non-CPU device may be needed.
+
+    ``cpu`` never needs torch, and a missing torch means the ``[diarize]`` extra
+    is not installed - pyannote itself will raise the actionable ImportError a
+    few lines later, so staying quiet here keeps that error path intact.
+
+    Args:
+        device: One of ``SUPPORTED_DIARIZATION_DEVICES``.
+
+    Returns:
+        ``(torch_module_or_None, resolved_device)``.
+    """
+    if device == "cpu":
+        return None, "cpu"
+    try:
+        # Intentional: diarization is optional and this torch import is gated
+        # behind the [diarize] extra, so the core ASR path stays torch-free.
+        import torch
+    except ImportError:
+        return None, "cpu"
+    return torch, _resolve_diarization_device(device, torch)
+
+
+def _load_pyannote_pipeline(device: str = DEFAULT_DIARIZATION_DEVICE) -> object:
     model_id = os.environ.get("PYANNOTE_MODEL_ID", DEFAULT_PYANNOTE_MODEL_ID)
     token = (
         os.environ.get("PYANNOTE_AUTH_TOKEN")
@@ -240,7 +296,8 @@ def _load_pyannote_pipeline() -> object:
         or os.environ.get("HF_TOKEN")
         or ""
     )
-    key = (model_id, token)
+    torch, resolved_device = _resolve_torch_device(device)
+    key = (model_id, token, resolved_device)
     cached = _PYANNOTE_PIPELINE_CACHE.get(key)
     if cached is not None:
         return cached
@@ -264,6 +321,18 @@ def _load_pyannote_pipeline() -> object:
             "Pipeline.from_pretrained returned None; pyannote could not download "
             "or load the pipeline configuration.",
         )
+    if resolved_device != "cpu" and torch is not None:
+        try:
+            pipeline.to(torch.device(resolved_device))
+        except Exception as exc:  # noqa: BLE001 - any backend gap must not be fatal
+            warnings.warn(
+                f"Could not move the pyannote pipeline to {resolved_device} "
+                f"({type(exc).__name__}: {exc}); falling back to CPU.",
+                stacklevel=2,
+            )
+            resolved_device = "cpu"
+            key = (model_id, token, resolved_device)
+
     _PYANNOTE_PIPELINE_CACHE[key] = pipeline
     return pipeline
 

--- a/mlx_qwen3_asr/diarization.py
+++ b/mlx_qwen3_asr/diarization.py
@@ -330,6 +330,18 @@ def _load_pyannote_pipeline(device: str = DEFAULT_DIARIZATION_DEVICE) -> object:
                 f"({type(exc).__name__}: {exc}); falling back to CPU.",
                 stacklevel=2,
             )
+            # Pipeline.to() moves sub-models in a loop, so a mid-loop failure
+            # leaves earlier components on the accelerator. Caching that mixed
+            # state under the CPU key would hand a later CPU caller a pipeline
+            # that dies on a device mismatch at inference time.
+            try:
+                pipeline.to(torch.device("cpu"))
+            except Exception as cpu_exc:  # noqa: BLE001 - unusable either way
+                raise RuntimeError(
+                    "Diarization pipeline was left on mixed devices after a "
+                    f"failed transfer to {resolved_device} and could not be "
+                    f"recovered to CPU ({type(cpu_exc).__name__}: {cpu_exc})."
+                ) from cpu_exc
             resolved_device = "cpu"
             key = (model_id, token, resolved_device)
 

--- a/mlx_qwen3_asr/diarization.py
+++ b/mlx_qwen3_asr/diarization.py
@@ -240,11 +240,13 @@ def diarize_chunk_items(
 
 
 _PYANNOTE_PIPELINE_CACHE: dict[tuple[str, str, str], object] = {}
-# Accelerators whose transfer already failed once in this process. Without this
-# every later call re-loads the pipeline, retries the same doomed transfer, and
-# warns again, because the fallback is cached under the CPU key rather than the
-# requested one.
-_UNAVAILABLE_DIARIZATION_DEVICES: set[str] = set()
+# Pipeline identities whose accelerator transfer already failed in this process,
+# keyed exactly like the cache: (model_id, token, device). Without this the
+# fallback lives under the CPU key, so every later call re-loads the pipeline,
+# retries the same doomed transfer, and warns again. Scoped per identity rather
+# than per device because MPS operator gaps are model-specific: one model
+# failing must not disable the accelerator for a different one.
+_UNAVAILABLE_DIARIZATION_DEVICES: set[tuple[str, str, str]] = set()
 
 
 def _resolve_diarization_device(requested: str, torch_module: Any) -> str:
@@ -290,10 +292,7 @@ def _resolve_torch_device(device: str) -> tuple[Any, str]:
         import torch
     except ImportError:
         return None, "cpu"
-    resolved = _resolve_diarization_device(device, torch)
-    if resolved in _UNAVAILABLE_DIARIZATION_DEVICES:
-        return torch, "cpu"
-    return torch, resolved
+    return torch, _resolve_diarization_device(device, torch)
 
 
 def _load_pyannote_pipeline(device: str = DEFAULT_DIARIZATION_DEVICE) -> object:
@@ -305,6 +304,8 @@ def _load_pyannote_pipeline(device: str = DEFAULT_DIARIZATION_DEVICE) -> object:
         or ""
     )
     torch, resolved_device = _resolve_torch_device(device)
+    if (model_id, token, resolved_device) in _UNAVAILABLE_DIARIZATION_DEVICES:
+        resolved_device = "cpu"
     key = (model_id, token, resolved_device)
     cached = _PYANNOTE_PIPELINE_CACHE.get(key)
     if cached is not None:
@@ -350,7 +351,7 @@ def _load_pyannote_pipeline(device: str = DEFAULT_DIARIZATION_DEVICE) -> object:
                     f"failed transfer to {resolved_device} and could not be "
                     f"recovered to CPU ({type(cpu_exc).__name__}: {cpu_exc})."
                 ) from cpu_exc
-            _UNAVAILABLE_DIARIZATION_DEVICES.add(resolved_device)
+            _UNAVAILABLE_DIARIZATION_DEVICES.add((model_id, token, resolved_device))
             resolved_device = "cpu"
             key = (model_id, token, resolved_device)
 

--- a/mlx_qwen3_asr/diarization.py
+++ b/mlx_qwen3_asr/diarization.py
@@ -240,6 +240,11 @@ def diarize_chunk_items(
 
 
 _PYANNOTE_PIPELINE_CACHE: dict[tuple[str, str, str], object] = {}
+# Accelerators whose transfer already failed once in this process. Without this
+# every later call re-loads the pipeline, retries the same doomed transfer, and
+# warns again, because the fallback is cached under the CPU key rather than the
+# requested one.
+_UNAVAILABLE_DIARIZATION_DEVICES: set[str] = set()
 
 
 def _resolve_diarization_device(requested: str, torch_module: Any) -> str:
@@ -285,7 +290,10 @@ def _resolve_torch_device(device: str) -> tuple[Any, str]:
         import torch
     except ImportError:
         return None, "cpu"
-    return torch, _resolve_diarization_device(device, torch)
+    resolved = _resolve_diarization_device(device, torch)
+    if resolved in _UNAVAILABLE_DIARIZATION_DEVICES:
+        return torch, "cpu"
+    return torch, resolved
 
 
 def _load_pyannote_pipeline(device: str = DEFAULT_DIARIZATION_DEVICE) -> object:
@@ -342,6 +350,7 @@ def _load_pyannote_pipeline(device: str = DEFAULT_DIARIZATION_DEVICE) -> object:
                     f"failed transfer to {resolved_device} and could not be "
                     f"recovered to CPU ({type(cpu_exc).__name__}: {cpu_exc})."
                 ) from cpu_exc
+            _UNAVAILABLE_DIARIZATION_DEVICES.add(resolved_device)
             resolved_device = "cpu"
             key = (model_id, token, resolved_device)
 

--- a/mlx_qwen3_asr/session.py
+++ b/mlx_qwen3_asr/session.py
@@ -10,11 +10,11 @@ import numpy as np
 
 from . import streaming as streaming_mod
 from .config import DEFAULT_MODEL_ID
+from .diarization import DEFAULT_DIARIZATION_DEVICE
 from .forced_aligner import ForcedAligner
 from .load_models import _resolve_path, load_model
 from .model import Qwen3ASRModel
 from .tokenizer import Tokenizer
-from .diarization import DEFAULT_DIARIZATION_DEVICE
 from .transcribe import (
     AudioInput,
     ProgressCallback,

--- a/mlx_qwen3_asr/session.py
+++ b/mlx_qwen3_asr/session.py
@@ -108,6 +108,7 @@ class Session:
             diarization_num_speakers=options.diarization_num_speakers,
             diarization_min_speakers=options.diarization_min_speakers,
             diarization_max_speakers=options.diarization_max_speakers,
+            diarization_device=options.diarization_device,
         )
         effective_return_timestamps = bool(
             options.return_timestamps or diarization_config is not None

--- a/mlx_qwen3_asr/session.py
+++ b/mlx_qwen3_asr/session.py
@@ -14,6 +14,7 @@ from .forced_aligner import ForcedAligner
 from .load_models import _resolve_path, load_model
 from .model import Qwen3ASRModel
 from .tokenizer import Tokenizer
+from .diarization import DEFAULT_DIARIZATION_DEVICE
 from .transcribe import (
     AudioInput,
     ProgressCallback,
@@ -76,6 +77,7 @@ class Session:
         diarization_num_speakers: Optional[int] = None,
         diarization_min_speakers: int = 1,
         diarization_max_speakers: int = 8,
+        diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
         return_chunks: bool = False,
         forced_aligner: Optional[Union[str, ForcedAligner]] = None,
         max_new_tokens: Optional[int] = None,
@@ -92,6 +94,7 @@ class Session:
             diarization_num_speakers=diarization_num_speakers,
             diarization_min_speakers=diarization_min_speakers,
             diarization_max_speakers=diarization_max_speakers,
+            diarization_device=diarization_device,
             return_chunks=return_chunks,
             forced_aligner=forced_aligner,
             dtype=self.dtype,
@@ -146,6 +149,7 @@ class Session:
         diarization_num_speakers: Optional[int] = None,
         diarization_min_speakers: int = 1,
         diarization_max_speakers: int = 8,
+        diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
         return_chunks: bool = False,
         forced_aligner: Optional[Union[str, ForcedAligner]] = None,
         max_new_tokens: Optional[int] = None,
@@ -162,6 +166,7 @@ class Session:
             diarization_num_speakers=diarization_num_speakers,
             diarization_min_speakers=diarization_min_speakers,
             diarization_max_speakers=diarization_max_speakers,
+            diarization_device=diarization_device,
             return_chunks=return_chunks,
             forced_aligner=forced_aligner,
             dtype=self.dtype,

--- a/mlx_qwen3_asr/transcribe.py
+++ b/mlx_qwen3_asr/transcribe.py
@@ -15,6 +15,7 @@ from .audio import SAMPLE_RATE, compute_features, load_audio_np
 from .chunking import split_audio_into_chunks
 from .config import DEFAULT_MODEL_ID
 from .diarization import (
+    DEFAULT_DIARIZATION_DEVICE,
     DiarizationConfig,
     build_speaker_segments_from_turns,
     diarize_chunk_items,
@@ -100,6 +101,7 @@ class TranscribeOptions:
     diarization_num_speakers: Optional[int] = None
     diarization_min_speakers: int = 1
     diarization_max_speakers: int = 8
+    diarization_device: str = DEFAULT_DIARIZATION_DEVICE
     return_chunks: bool = False
     forced_aligner: Optional[Union[str, ForcedAligner]] = None
     dtype: mx.Dtype = mx.float16
@@ -140,6 +142,7 @@ def _build_transcribe_options(
     diarization_num_speakers: Optional[int] = None,
     diarization_min_speakers: int = 1,
     diarization_max_speakers: int = 8,
+    diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
     return_chunks: bool = False,
     forced_aligner: Optional[Union[str, ForcedAligner]] = None,
     dtype: mx.Dtype = mx.float16,
@@ -156,6 +159,7 @@ def _build_transcribe_options(
         diarization_num_speakers=diarization_num_speakers,
         diarization_min_speakers=diarization_min_speakers,
         diarization_max_speakers=diarization_max_speakers,
+        diarization_device=diarization_device,
         return_chunks=return_chunks,
         forced_aligner=forced_aligner,
         dtype=dtype,
@@ -179,6 +183,7 @@ def _transcribe_options_to_kwargs(
         "diarization_num_speakers": options.diarization_num_speakers,
         "diarization_min_speakers": options.diarization_min_speakers,
         "diarization_max_speakers": options.diarization_max_speakers,
+        "diarization_device": options.diarization_device,
         "return_chunks": options.return_chunks,
         "forced_aligner": options.forced_aligner,
         "max_new_tokens": options.max_new_tokens,
@@ -213,6 +218,7 @@ def _resolve_runtime_options(
         diarization_num_speakers=options.diarization_num_speakers,
         diarization_min_speakers=options.diarization_min_speakers,
         diarization_max_speakers=options.diarization_max_speakers,
+        diarization_device=options.diarization_device,
     )
     effective_return_timestamps = bool(
         options.return_timestamps or diarization_config is not None
@@ -233,6 +239,7 @@ def transcribe(
     diarization_num_speakers: Optional[int] = None,
     diarization_min_speakers: int = 1,
     diarization_max_speakers: int = 8,
+    diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
     return_chunks: bool = False,
     forced_aligner: Optional[Union[str, ForcedAligner]] = None,
     dtype: mx.Dtype = mx.float16,
@@ -266,6 +273,7 @@ def transcribe(
         diarization_num_speakers: Optional fixed speaker count override.
         diarization_min_speakers: Lower bound for auto speaker estimation.
         diarization_max_speakers: Upper bound for auto speaker estimation.
+        diarization_device: Device for the pyannote pipeline ("auto", "cpu", "mps", "cuda").
         return_chunks: Whether to return chunk-level transcript metadata.
         forced_aligner: Path/name of forced aligner model or prebuilt aligner object.
         dtype: Model dtype
@@ -286,6 +294,7 @@ def transcribe(
         diarization_num_speakers=diarization_num_speakers,
         diarization_min_speakers=diarization_min_speakers,
         diarization_max_speakers=diarization_max_speakers,
+        diarization_device=diarization_device,
         return_chunks=return_chunks,
         forced_aligner=forced_aligner,
         dtype=dtype,
@@ -346,6 +355,7 @@ async def transcribe_async(
     diarization_num_speakers: Optional[int] = None,
     diarization_min_speakers: int = 1,
     diarization_max_speakers: int = 8,
+    diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
     return_chunks: bool = False,
     forced_aligner: Optional[Union[str, ForcedAligner]] = None,
     dtype: mx.Dtype = mx.float16,
@@ -363,6 +373,7 @@ async def transcribe_async(
         diarization_num_speakers=diarization_num_speakers,
         diarization_min_speakers=diarization_min_speakers,
         diarization_max_speakers=diarization_max_speakers,
+        diarization_device=diarization_device,
         return_chunks=return_chunks,
         forced_aligner=forced_aligner,
         dtype=dtype,
@@ -392,6 +403,7 @@ def transcribe_batch(
     diarization_num_speakers: Optional[int] = None,
     diarization_min_speakers: int = 1,
     diarization_max_speakers: int = 8,
+    diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
     return_chunks: bool = False,
     forced_aligner: Optional[Union[str, ForcedAligner]] = None,
     dtype: mx.Dtype = mx.float16,
@@ -428,6 +440,7 @@ def transcribe_batch(
         diarization_num_speakers=diarization_num_speakers,
         diarization_min_speakers=diarization_min_speakers,
         diarization_max_speakers=diarization_max_speakers,
+        diarization_device=diarization_device,
         return_chunks=return_chunks,
         forced_aligner=forced_aligner,
         dtype=dtype,
@@ -505,6 +518,7 @@ async def transcribe_batch_async(
     diarization_num_speakers: Optional[int] = None,
     diarization_min_speakers: int = 1,
     diarization_max_speakers: int = 8,
+    diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
     return_chunks: bool = False,
     forced_aligner: Optional[Union[str, ForcedAligner]] = None,
     dtype: mx.Dtype = mx.float16,
@@ -521,6 +535,7 @@ async def transcribe_batch_async(
         diarization_num_speakers=diarization_num_speakers,
         diarization_min_speakers=diarization_min_speakers,
         diarization_max_speakers=diarization_max_speakers,
+        diarization_device=diarization_device,
         return_chunks=return_chunks,
         forced_aligner=forced_aligner,
         dtype=dtype,
@@ -626,6 +641,7 @@ def _resolve_diarization_config(
     diarization_num_speakers: Optional[int],
     diarization_min_speakers: int,
     diarization_max_speakers: int,
+    diarization_device: str = DEFAULT_DIARIZATION_DEVICE,
 ) -> Optional[DiarizationConfig]:
     if not diarize:
         if diarization_num_speakers is not None:
@@ -637,6 +653,7 @@ def _resolve_diarization_config(
         num_speakers=diarization_num_speakers,
         min_speakers=diarization_min_speakers,
         max_speakers=diarization_max_speakers,
+        device=diarization_device,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -475,7 +475,7 @@ def test_cli_diarize_preflight_emits_token_hint(monkeypatch, capsys):
     monkeypatch.delenv("PYANNOTE_AUTH_TOKEN", raising=False)
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.delenv("HUGGINGFACE_TOKEN", raising=False)
-    monkeypatch.setattr(cli, "_ensure_diarization_backend_ready", lambda: None)
+    monkeypatch.setattr(cli, "_ensure_diarization_backend_ready", lambda device: None)
 
     cli._preflight_diarization_runtime()  # noqa: SLF001
     assert "default pyannote/speaker-diarization-community-1" in capsys.readouterr().err
@@ -489,7 +489,7 @@ def test_cli_diarize_preflight_checks_backend_readiness(monkeypatch):
     monkeypatch.setattr(
         cli,
         "_ensure_diarization_backend_ready",
-        lambda: called.__setitem__("value", True),
+        lambda device: called.__setitem__("value", True),
     )
 
     cli._preflight_diarization_runtime()  # noqa: SLF001
@@ -503,7 +503,7 @@ def test_cli_diarize_preflight_fails_fast_when_backend_unavailable(monkeypatch, 
     monkeypatch.setattr(
         cli,
         "_ensure_diarization_backend_ready",
-        lambda: (_ for _ in ()).throw(RuntimeError("backend unavailable")),
+        lambda device: (_ for _ in ()).throw(RuntimeError("backend unavailable")),
     )
 
     with pytest.raises(SystemExit) as exc:
@@ -586,7 +586,7 @@ def test_cli_diarize_auto_enables_timestamps_and_forwards_args(monkeypatch, tmp_
             str(audio_path),
         ],
     )
-    monkeypatch.setattr(cli, "_preflight_diarization_runtime", lambda: None)
+    monkeypatch.setattr(cli, "_preflight_diarization_runtime", lambda device: None)
     monkeypatch.setattr(transcribe_mod, "transcribe", _fake_transcribe)
     monkeypatch.setattr(writers_mod, "get_writer", lambda fmt: (lambda result, out_path: None))
 
@@ -619,3 +619,25 @@ def test_cli_streaming_rejects_subtitle_formats(monkeypatch, capsys, tmp_path):
         cli.main()
     assert exc.value.code == 1
     assert "require offline transcription" in capsys.readouterr().err
+
+
+def test_cli_diarize_preflight_uses_the_requested_device(monkeypatch):
+    """Preflight must warm the same device the run will use.
+
+    Otherwise it caches a pipeline under a different device key and the
+    transcription pays for a second load - and an explicit --diarize-device cpu
+    would still put the preflight pipeline on the accelerator.
+    """
+    cli = __import__("mlx_qwen3_asr.cli", fromlist=["main"])
+    seen: dict = {}
+
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(
+        cli,
+        "_ensure_diarization_backend_ready",
+        lambda device: seen.__setitem__("device", device),
+    )
+
+    cli._preflight_diarization_runtime("cpu")  # noqa: SLF001
+
+    assert seen["device"] == "cpu"

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -383,7 +383,7 @@ def test_load_pyannote_pipeline_uses_pyannote4_token_kwarg(monkeypatch):
     monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", set())
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
-    dmod._load_pyannote_pipeline()  # noqa: SLF001
+    dmod._load_pyannote_pipeline(device="cpu")  # noqa: SLF001
 
     assert calls == {
         "model_id": DEFAULT_PYANNOTE_MODEL_ID,
@@ -415,7 +415,7 @@ def test_load_pyannote_pipeline_defaults_to_token_for_kwargs_signature(monkeypat
     monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", set())
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
-    dmod._load_pyannote_pipeline()  # noqa: SLF001
+    dmod._load_pyannote_pipeline(device="cpu")  # noqa: SLF001
 
     assert calls == {
         "model_id": DEFAULT_PYANNOTE_MODEL_ID,
@@ -445,7 +445,7 @@ def test_load_pyannote_pipeline_falls_back_to_pyannote3_auth_kwarg(monkeypatch):
     monkeypatch.setenv("PYANNOTE_MODEL_ID", "pyannote/speaker-diarization-3.1")
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
-    dmod._load_pyannote_pipeline()  # noqa: SLF001
+    dmod._load_pyannote_pipeline(device="cpu")  # noqa: SLF001
 
     assert calls == {
         "model_id": "pyannote/speaker-diarization-3.1",
@@ -475,7 +475,7 @@ def test_load_pyannote_pipeline_wraps_from_pretrained_errors(monkeypatch):
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
     with pytest.raises(RuntimeError, match="Root cause: RuntimeError: 401 unauthorized"):
-        dmod._load_pyannote_pipeline()  # noqa: SLF001
+        dmod._load_pyannote_pipeline(device="cpu")  # noqa: SLF001
 
 
 def test_load_pyannote_pipeline_rejects_none_return(monkeypatch):
@@ -503,7 +503,7 @@ def test_load_pyannote_pipeline_rejects_none_return(monkeypatch):
         RuntimeError,
         match=r"Root cause: Pipeline\.from_pretrained returned None",
     ):
-        dmod._load_pyannote_pipeline()  # noqa: SLF001
+        dmod._load_pyannote_pipeline(device="cpu")  # noqa: SLF001
 
 
 def test_diarize_word_segments_adds_speaker_labels():
@@ -783,15 +783,47 @@ def test_load_pyannote_pipeline_does_not_retry_a_device_that_already_failed(monk
 
     assert first is second
     assert loads["count"] == 1, "the failed accelerator was retried"
-    assert diarization._UNAVAILABLE_DIARIZATION_DEVICES == {"mps"}
+    assert diarization._UNAVAILABLE_DIARIZATION_DEVICES == {
+        (DEFAULT_PYANNOTE_MODEL_ID, "", "mps")
+    }
 
 
 def test_explicit_request_for_a_known_bad_device_resolves_to_cpu(monkeypatch):
     _isolate_pyannote_env(monkeypatch)
     diarization = importlib.import_module("mlx_qwen3_asr.diarization")
-    monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", {"mps"})
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", {})
+    monkeypatch.setattr(
+        diarization,
+        "_UNAVAILABLE_DIARIZATION_DEVICES",
+        {(DEFAULT_PYANNOTE_MODEL_ID, "", "mps")},
+    )
     monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+    pipeline = _MovablePipeline()
+    _install_fake_pyannote(monkeypatch, pipeline)
 
-    _, resolved = diarization._resolve_torch_device("mps")
+    diarization._load_pyannote_pipeline("mps")
 
-    assert resolved == "cpu"
+    assert pipeline.moved_to == [], "a known-bad accelerator must not be retried"
+
+
+def test_failed_device_is_remembered_per_model_not_globally(monkeypatch):
+    """One model failing on MPS must not disable MPS for a different model.
+
+    MPS operator gaps are model-specific, so a process-wide flag would strand
+    every other pipeline on CPU for the rest of the run.
+    """
+    _isolate_pyannote_env(monkeypatch)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", {})
+    monkeypatch.setattr(
+        diarization,
+        "_UNAVAILABLE_DIARIZATION_DEVICES",
+        {("some/other-model", "", "mps")},
+    )
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+    pipeline = _MovablePipeline()
+    _install_fake_pyannote(monkeypatch, pipeline)
+
+    diarization._load_pyannote_pipeline("auto")
+
+    assert pipeline.moved_to == ["device:mps"]

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -593,12 +593,24 @@ class _FakeTorch:
 
 
 class _MovablePipeline:
-    def __init__(self, fail: bool = False):
+    """Fake pipeline that can fail accelerator transfers but accept CPU ones.
+
+    Mirrors pyannote's ``Pipeline.to``, which moves sub-models in a loop: a
+    mid-loop failure leaves earlier components on the accelerator, so the
+    recovery path must be able to move what is left back to CPU.
+    """
+
+    def __init__(self, fail_accelerator: bool = False, fail_cpu: bool = False):
         self.moved_to: list[str] = []
-        self._fail = fail
+        self._fail_accelerator = fail_accelerator
+        self._fail_cpu = fail_cpu
 
     def to(self, device):
-        if self._fail:
+        is_cpu = str(device).endswith("cpu")
+        if is_cpu and self._fail_cpu:
+            raise RuntimeError("cpu transfer is broken too")
+        if not is_cpu and self._fail_accelerator:
+            self.moved_to.append(f"{device}:partial")
             raise RuntimeError("backend does not support this op")
         self.moved_to.append(device)
         return self
@@ -643,6 +655,13 @@ def test_resolve_diarization_device_survives_torch_without_mps_attr():
     assert _resolve_diarization_device("auto", torch_stub) == "cpu"
 
 
+def _isolate_pyannote_env(monkeypatch):
+    """Keep cache-key assertions independent of the developer's environment."""
+    for var in ("PYANNOTE_AUTH_TOKEN", "HUGGINGFACE_TOKEN", "HF_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+
+
 def _install_fake_pyannote(monkeypatch, pipeline):
     fake_module = types.ModuleType("pyannote.audio")
     fake_module.Pipeline = types.SimpleNamespace(
@@ -678,19 +697,41 @@ def test_load_pyannote_pipeline_skips_move_for_cpu(monkeypatch):
 
 
 def test_load_pyannote_pipeline_falls_back_when_move_fails(monkeypatch):
+    _isolate_pyannote_env(monkeypatch)
     diarization = importlib.import_module("mlx_qwen3_asr.diarization")
-    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", {})
+    cache: dict = {}
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", cache)
     monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
-    pipeline = _MovablePipeline(fail=True)
+    pipeline = _MovablePipeline(fail_accelerator=True)
     _install_fake_pyannote(monkeypatch, pipeline)
 
     with pytest.warns(UserWarning, match="falling back to CPU"):
         loaded = diarization._load_pyannote_pipeline("auto")
 
     assert loaded is pipeline
+    # The partially moved pipeline must be pulled back to CPU before caching,
+    # otherwise a later CPU caller inherits a mixed-device pipeline.
+    assert pipeline.moved_to == ["device:mps:partial", "device:cpu"]
+    assert set(cache) == {(DEFAULT_PYANNOTE_MODEL_ID, "", "cpu")}
+
+
+def test_load_pyannote_pipeline_raises_when_cpu_recovery_also_fails(monkeypatch):
+    _isolate_pyannote_env(monkeypatch)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    cache: dict = {}
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", cache)
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+    pipeline = _MovablePipeline(fail_accelerator=True, fail_cpu=True)
+    _install_fake_pyannote(monkeypatch, pipeline)
+
+    with pytest.warns(UserWarning), pytest.raises(RuntimeError, match="mixed devices"):
+        diarization._load_pyannote_pipeline("auto")
+
+    assert cache == {}, "an unusable pipeline must never be cached"
 
 
 def test_load_pyannote_pipeline_caches_per_device(monkeypatch):
+    _isolate_pyannote_env(monkeypatch)
     diarization = importlib.import_module("mlx_qwen3_asr.diarization")
     cache: dict = {}
     monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", cache)

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -10,8 +10,10 @@ import numpy as np
 import pytest
 
 from mlx_qwen3_asr.diarization import (
+    DEFAULT_DIARIZATION_DEVICE,
     DEFAULT_PYANNOTE_MODEL_ID,
     DEFAULT_SPEAKER_LABEL,
+    _resolve_diarization_device,
     build_speaker_segments_from_turns,
     diarize_chunk_items,
     diarize_word_segments,
@@ -240,7 +242,8 @@ def test_infer_speaker_turns_falls_back_when_pyannote4_exclusive_is_empty(monkey
 def test_infer_speaker_turns_raises_helpful_error_when_dependency_missing(monkeypatch):
     dmod = importlib.import_module("mlx_qwen3_asr.diarization")
 
-    def _raise_import_error():
+    def _raise_import_error(device=DEFAULT_DIARIZATION_DEVICE):
+        _ = device
         raise ImportError("missing pyannote")
 
     monkeypatch.setattr(dmod, "_load_pyannote_pipeline", _raise_import_error)
@@ -568,3 +571,133 @@ def test_build_speaker_segments_from_turns_keeps_empty_turn_text():
     assert speaker_segments[0]["text"] == "hello"
     assert speaker_segments[1]["speaker"] == "SPEAKER_01"
     assert speaker_segments[1]["text"] == ""
+
+
+class _FakeBackendFlag:
+    def __init__(self, available: bool):
+        self._available = available
+
+    def is_available(self) -> bool:
+        return self._available
+
+
+class _FakeTorch:
+    """Minimal torch stand-in for device resolution tests."""
+
+    def __init__(self, *, mps: bool = False, cuda: bool = False):
+        self.backends = types.SimpleNamespace(mps=_FakeBackendFlag(mps))
+        self.cuda = _FakeBackendFlag(cuda)
+
+    def device(self, name: str) -> str:
+        return f"device:{name}"
+
+
+class _MovablePipeline:
+    def __init__(self, fail: bool = False):
+        self.moved_to: list[str] = []
+        self._fail = fail
+
+    def to(self, device):
+        if self._fail:
+            raise RuntimeError("backend does not support this op")
+        self.moved_to.append(device)
+        return self
+
+
+def test_validate_diarization_config_defaults_device_to_auto():
+    cfg = validate_diarization_config(
+        num_speakers=None, min_speakers=1, max_speakers=8
+    )
+    assert cfg.device == "auto"
+
+
+def test_validate_diarization_config_rejects_unknown_device():
+    with pytest.raises(ValueError, match="diarization_device"):
+        validate_diarization_config(
+            num_speakers=None, min_speakers=1, max_speakers=8, device="tpu"
+        )
+
+
+@pytest.mark.parametrize(
+    ("mps", "cuda", "expected"),
+    [
+        (True, False, "mps"),
+        (False, True, "cuda"),
+        (False, False, "cpu"),
+        (True, True, "mps"),
+    ],
+)
+def test_resolve_diarization_device_auto_prefers_fastest(mps, cuda, expected):
+    torch_stub = _FakeTorch(mps=mps, cuda=cuda)
+    assert _resolve_diarization_device("auto", torch_stub) == expected
+
+
+def test_resolve_diarization_device_respects_explicit_choice():
+    torch_stub = _FakeTorch(mps=True)
+    assert _resolve_diarization_device("cpu", torch_stub) == "cpu"
+
+
+def test_resolve_diarization_device_survives_torch_without_mps_attr():
+    torch_stub = _FakeTorch()
+    torch_stub.backends = types.SimpleNamespace()
+    assert _resolve_diarization_device("auto", torch_stub) == "cpu"
+
+
+def _install_fake_pyannote(monkeypatch, pipeline):
+    fake_module = types.ModuleType("pyannote.audio")
+    fake_module.Pipeline = types.SimpleNamespace(
+        from_pretrained=lambda model_id, **kwargs: pipeline
+    )
+    monkeypatch.setitem(sys.modules, "pyannote", types.ModuleType("pyannote"))
+    monkeypatch.setitem(sys.modules, "pyannote.audio", fake_module)
+
+
+def test_load_pyannote_pipeline_moves_to_resolved_device(monkeypatch):
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", {})
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+    pipeline = _MovablePipeline()
+    _install_fake_pyannote(monkeypatch, pipeline)
+
+    loaded = diarization._load_pyannote_pipeline("auto")
+
+    assert loaded is pipeline
+    assert pipeline.moved_to == ["device:mps"]
+
+
+def test_load_pyannote_pipeline_skips_move_for_cpu(monkeypatch):
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", {})
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+    pipeline = _MovablePipeline()
+    _install_fake_pyannote(monkeypatch, pipeline)
+
+    diarization._load_pyannote_pipeline("cpu")
+
+    assert pipeline.moved_to == []
+
+
+def test_load_pyannote_pipeline_falls_back_when_move_fails(monkeypatch):
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", {})
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+    pipeline = _MovablePipeline(fail=True)
+    _install_fake_pyannote(monkeypatch, pipeline)
+
+    with pytest.warns(UserWarning, match="falling back to CPU"):
+        loaded = diarization._load_pyannote_pipeline("auto")
+
+    assert loaded is pipeline
+
+
+def test_load_pyannote_pipeline_caches_per_device(monkeypatch):
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    cache: dict = {}
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", cache)
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+    _install_fake_pyannote(monkeypatch, _MovablePipeline())
+
+    diarization._load_pyannote_pipeline("cpu")
+    diarization._load_pyannote_pipeline("mps")
+
+    assert {key[2] for key in cache} == {"cpu", "mps"}

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -379,6 +379,8 @@ def test_load_pyannote_pipeline_uses_pyannote4_token_kwarg(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
     monkeypatch.setenv("PYANNOTE_AUTH_TOKEN", "hf_test")
     monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", set())
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
     dmod._load_pyannote_pipeline()  # noqa: SLF001
@@ -409,6 +411,8 @@ def test_load_pyannote_pipeline_defaults_to_token_for_kwargs_signature(monkeypat
     monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
     monkeypatch.setenv("PYANNOTE_AUTH_TOKEN", "hf_test")
     monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", set())
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
     dmod._load_pyannote_pipeline()  # noqa: SLF001
@@ -466,6 +470,8 @@ def test_load_pyannote_pipeline_wraps_from_pretrained_errors(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyannote", fake_pkg)
     monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
     monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", set())
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
     with pytest.raises(RuntimeError, match="Root cause: RuntimeError: 401 unauthorized"):
@@ -489,6 +495,8 @@ def test_load_pyannote_pipeline_rejects_none_return(monkeypatch):
     monkeypatch.setitem(sys.modules, "pyannote", fake_pkg)
     monkeypatch.setitem(sys.modules, "pyannote.audio", fake_audio_module)
     monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", set())
     dmod._PYANNOTE_PIPELINE_CACHE.clear()  # noqa: SLF001
 
     with pytest.raises(
@@ -660,6 +668,8 @@ def _isolate_pyannote_env(monkeypatch):
     for var in ("PYANNOTE_AUTH_TOKEN", "HUGGINGFACE_TOKEN", "HF_TOKEN"):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.delenv("PYANNOTE_MODEL_ID", raising=False)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", set())
 
 
 def _install_fake_pyannote(monkeypatch, pipeline):
@@ -742,3 +752,46 @@ def test_load_pyannote_pipeline_caches_per_device(monkeypatch):
     diarization._load_pyannote_pipeline("mps")
 
     assert {key[2] for key in cache} == {"cpu", "mps"}
+
+
+def test_load_pyannote_pipeline_does_not_retry_a_device_that_already_failed(monkeypatch):
+    """A failed accelerator must be remembered for the rest of the process.
+
+    The fallback pipeline is cached under the CPU key, so without this the next
+    `auto` call misses its own key, reloads the pipeline, retries the same
+    doomed transfer, and warns again - every single call.
+    """
+    _isolate_pyannote_env(monkeypatch)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_PYANNOTE_PIPELINE_CACHE", {})
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+
+    loads = {"count": 0}
+
+    def _load(model_id, **kwargs):
+        loads["count"] += 1
+        return _MovablePipeline(fail_accelerator=True)
+
+    fake_module = types.ModuleType("pyannote.audio")
+    fake_module.Pipeline = types.SimpleNamespace(from_pretrained=_load)
+    monkeypatch.setitem(sys.modules, "pyannote", types.ModuleType("pyannote"))
+    monkeypatch.setitem(sys.modules, "pyannote.audio", fake_module)
+
+    with pytest.warns(UserWarning, match="falling back to CPU"):
+        first = diarization._load_pyannote_pipeline("auto")
+    second = diarization._load_pyannote_pipeline("auto")
+
+    assert first is second
+    assert loads["count"] == 1, "the failed accelerator was retried"
+    assert diarization._UNAVAILABLE_DIARIZATION_DEVICES == {"mps"}
+
+
+def test_explicit_request_for_a_known_bad_device_resolves_to_cpu(monkeypatch):
+    _isolate_pyannote_env(monkeypatch)
+    diarization = importlib.import_module("mlx_qwen3_asr.diarization")
+    monkeypatch.setattr(diarization, "_UNAVAILABLE_DIARIZATION_DEVICES", {"mps"})
+    monkeypatch.setitem(sys.modules, "torch", _FakeTorch(mps=True))
+
+    _, resolved = diarization._resolve_torch_device("mps")
+
+    assert resolved == "cpu"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -356,3 +356,69 @@ def test_session_transcribe_async_wrapper(monkeypatch):
 
     out = asyncio.run(session.transcribe_async(np.zeros(10, dtype=np.float32)))
     assert out.text == "ok-async"
+
+
+def _stub_session(monkeypatch, calls):
+    """Session with every heavy dependency replaced, capturing the diarization config."""
+
+    class _DummyTokenizer:
+        def __init__(self, path):  # noqa: ANN001
+            self.path = path
+
+    class _DummyModel:
+        pass
+
+    monkeypatch.setattr(sessmod, "Tokenizer", _DummyTokenizer)
+    monkeypatch.setattr(sessmod, "load_model", lambda model, dtype: (_DummyModel(), object()))
+    monkeypatch.setattr(sessmod, "_resolve_path", lambda model: "/tmp/resolved-model")
+    monkeypatch.setattr(sessmod, "_to_audio_np", lambda audio: np.zeros(160, dtype=np.float32))
+    monkeypatch.setattr(sessmod, "_resolve_aligner", lambda rt, fa: "ALIGNER")
+    monkeypatch.setattr(sessmod, "_resolve_draft_model", lambda **kwargs: None)
+
+    real_resolve = sessmod._resolve_diarization_config
+
+    def spy_resolve(**kwargs):  # noqa: ANN003
+        calls.update(kwargs)
+        return real_resolve(**kwargs)
+
+    monkeypatch.setattr(sessmod, "_resolve_diarization_config", spy_resolve)
+    monkeypatch.setattr(
+        sessmod,
+        "_transcribe_loaded_components",
+        lambda **kwargs: TranscriptionResult(text="ok", language="English"),
+    )
+    return sessmod.Session("repo/a", dtype=mx.float32)
+
+
+def test_session_transcribe_forwards_the_requested_diarization_device(monkeypatch):
+    """Accepting the option is not the same as honouring it.
+
+    `Session.transcribe` built the options with the device but then called
+    `_resolve_diarization_config` without it, so an explicit device was silently
+    replaced by `auto` - the caller got the accelerator they asked not to use.
+    """
+    calls: dict = {}
+    session = _stub_session(monkeypatch, calls)
+
+    session.transcribe(
+        np.zeros(160, dtype=np.float32),
+        diarize=True,
+        diarization_device="cpu",
+    )
+
+    assert calls["diarization_device"] == "cpu"
+
+
+def test_session_transcribe_async_forwards_the_requested_diarization_device(monkeypatch):
+    calls: dict = {}
+    session = _stub_session(monkeypatch, calls)
+
+    asyncio.run(
+        session.transcribe_async(
+            np.zeros(160, dtype=np.float32),
+            diarize=True,
+            diarization_device="cpu",
+        )
+    )
+
+    assert calls["diarization_device"] == "cpu"

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1032,3 +1032,49 @@ def test_every_public_entry_point_exposes_all_transcribe_options():
             f"{func.__qualname__} does not expose {sorted(missing)}; "
             "the option would be silently dropped for its callers"
         )
+
+
+def test_every_resolve_diarization_config_call_forwards_all_options():
+    """Accepting an option is not the same as honouring it.
+
+    This bug class bit this feature twice: `Session.transcribe` first failed to
+    *accept* `diarization_device` (a loud TypeError), then accepted it and
+    dropped it before `_resolve_diarization_config` (silent - the caller got the
+    accelerator they asked not to use). A signature check catches the first, not
+    the second.
+
+    So assert the invariant directly: every call site passes every parameter the
+    resolver declares. Adding an option and forgetting one call site fails here
+    instead of silently degrading to the default.
+    """
+    import ast
+    import inspect
+    import pathlib
+
+    from mlx_qwen3_asr.transcribe import _resolve_diarization_config
+
+    expected = {
+        name
+        for name, param in inspect.signature(_resolve_diarization_config).parameters.items()
+        if param.kind is inspect.Parameter.KEYWORD_ONLY
+        or param.default is not inspect.Parameter.empty
+    }
+    assert expected, "resolver has no keyword parameters; test needs updating"
+
+    package = pathlib.Path(inspect.getfile(_resolve_diarization_config)).parent
+    call_sites = []
+    for path in sorted(package.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if name != "_resolve_diarization_config":
+                continue
+            passed = {kw.arg for kw in node.keywords if kw.arg is not None}
+            call_sites.append((f"{path.name}:{node.lineno}", expected - passed))
+
+    assert call_sites, "no call sites found; the test is not checking anything"
+    offenders = {site: sorted(missing) for site, missing in call_sites if missing}
+    assert not offenders, f"call sites drop options instead of forwarding them: {offenders}"

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -951,15 +951,15 @@ def test_transcribe_async_wrapper(monkeypatch):
     assert result.text == "hello world"
 
 
-def test_option_kwargs_are_accepted_by_every_consumer():
-    """Every key `_transcribe_options_to_kwargs` emits must bind to every
-    signature it is splatted into.
+def test_option_kwargs_bind_to_every_splat_consumer():
+    """Every key `_transcribe_options_to_kwargs` emits must bind to the
+    signatures that dict is splatted into.
 
     Adding an option and updating only some consumers is a TypeError raised at
-    call time, from a code path a unit test may never exercise -- e.g. adding
-    `diarization_device` to the dict while `Session.transcribe` still lacked
-    the parameter broke every async session transcription, including with
-    `diarize=False`. Checking the signatures statically catches the whole class.
+    call time, from a path a unit test may never exercise -- adding
+    `diarization_device` to the dict while `Session.transcribe` still lacked the
+    parameter broke every async session transcription, including with
+    `diarize=False`.
     """
     import inspect
 
@@ -972,7 +972,6 @@ def test_option_kwargs_are_accepted_by_every_consumer():
     )
 
     options = _build_transcribe_options()
-
     consumers = [
         (transcribe, _transcribe_options_to_kwargs(options), ("dummy.wav",)),
         (transcribe_batch, _transcribe_options_to_kwargs(options), (["dummy.wav"],)),
@@ -988,3 +987,48 @@ def test_option_kwargs_are_accepted_by_every_consumer():
             inspect.signature(func).bind(*args, **kwargs)
         except TypeError as exc:  # pragma: no cover - failure path is the point
             pytest.fail(f"{func.__qualname__} cannot accept option kwargs: {exc}")
+
+
+def test_every_public_entry_point_exposes_all_transcribe_options():
+    """The async wrappers are producers, not consumers, of the option dict.
+
+    A wrapper missing a parameter does not raise -- it silently drops the option
+    and the caller gets the default, which is worse than the TypeError the bind
+    test above catches. So check the parameter surface of all six public entry
+    points, not just the three the dict is splatted into.
+
+    `dtype` is deliberately absent from the Session methods: the session owns
+    the model and its dtype, which is what `include_dtype=False` encodes.
+    """
+    import inspect
+
+    from mlx_qwen3_asr.session import Session
+    from mlx_qwen3_asr.transcribe import (
+        _build_transcribe_options,
+        _transcribe_options_to_kwargs,
+        transcribe,
+        transcribe_async,
+        transcribe_batch,
+        transcribe_batch_async,
+    )
+
+    options = _build_transcribe_options()
+    module_level = set(_transcribe_options_to_kwargs(options))
+    session_level = set(_transcribe_options_to_kwargs(options, include_dtype=False))
+
+    surfaces = [
+        (transcribe, module_level),
+        (transcribe_async, module_level),
+        (transcribe_batch, module_level),
+        (transcribe_batch_async, module_level),
+        (Session.transcribe, session_level),
+        (Session.transcribe_async, session_level),
+    ]
+
+    for func, expected in surfaces:
+        params = set(inspect.signature(func).parameters)
+        missing = expected - params
+        assert not missing, (
+            f"{func.__qualname__} does not expose {sorted(missing)}; "
+            "the option would be silently dropped for its callers"
+        )

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -949,3 +949,42 @@ def test_transcribe_async_wrapper(monkeypatch):
 
     result = asyncio.run(transcribe_async(np.zeros(3200, dtype=np.float32)))
     assert result.text == "hello world"
+
+
+def test_option_kwargs_are_accepted_by_every_consumer():
+    """Every key `_transcribe_options_to_kwargs` emits must bind to every
+    signature it is splatted into.
+
+    Adding an option and updating only some consumers is a TypeError raised at
+    call time, from a code path a unit test may never exercise -- e.g. adding
+    `diarization_device` to the dict while `Session.transcribe` still lacked
+    the parameter broke every async session transcription, including with
+    `diarize=False`. Checking the signatures statically catches the whole class.
+    """
+    import inspect
+
+    from mlx_qwen3_asr.session import Session
+    from mlx_qwen3_asr.transcribe import (
+        _build_transcribe_options,
+        _transcribe_options_to_kwargs,
+        transcribe,
+        transcribe_batch,
+    )
+
+    options = _build_transcribe_options()
+
+    consumers = [
+        (transcribe, _transcribe_options_to_kwargs(options), ("dummy.wav",)),
+        (transcribe_batch, _transcribe_options_to_kwargs(options), (["dummy.wav"],)),
+        (
+            Session.transcribe,
+            _transcribe_options_to_kwargs(options, include_dtype=False),
+            (None, "dummy.wav"),
+        ),
+    ]
+
+    for func, kwargs, args in consumers:
+        try:
+            inspect.signature(func).bind(*args, **kwargs)
+        except TypeError as exc:  # pragma: no cover - failure path is the point
+            pytest.fail(f"{func.__qualname__} cannot accept option kwargs: {exc}")


### PR DESCRIPTION
## Summary

- **What changed:** Added `--diarize-device {auto,cpu,mps,cuda}` (default `auto`) and gave the pyannote pipeline an explicit device. `auto` resolves to MPS, then CUDA, then CPU.
- **Why:** `_load_pyannote_pipeline` never called `.to(device)`, so diarization always ran on CPU with no option or documented workaround. On Apple Silicon this is the dominant cost of a diarized transcription — with the 8-bit MLX weights, ASR of a 265s clip takes ~14s while CPU diarization takes ~117s, so the GPU sits idle through roughly 85% of the wall clock.

Three details in the diff are deliberate and worth a reviewer's attention:

1. **The pipeline cache key now includes the resolved device.** Keying only on `(model_id, token)` hands a CPU-resident pipeline to a later MPS caller — a silent, unreproducible slowdown, which is the worst failure mode available here.
2. **torch stays lazy.** `cpu` does not import torch at all, and a missing torch resolves to CPU rather than raising. My first attempt imported torch unconditionally and hijacked the existing "pyannote missing → actionable ImportError" path, breaking 5 existing tests in an environment that installs `[dev]` without `[diarize]`. The core ASR path remains torch-free.
3. **`.to(device)` is never fatal.** MPS operator gaps are real; the code warns, falls back to CPU, and still returns a transcript.

The resolver takes the torch module as an argument rather than importing it, so the mps and cuda branches are unit-testable on any CI host without a GPU.

## Evidence

- **Tests/commands run:**
  - `python -m pytest tests/ -q` → **537 passed, 1 failed, 3 skipped**
  - Baseline on clean `main` → **525 passed, 1 failed, 3 skipped**
  - The single failure is `tests/test_audio.py::TestLogMelSpectrogram::test_raises_for_too_short_audio`, which **pre-exists on `main`** (MLX now raises `[as_strided] Negative dimensions not allowed.` instead of a "too short" message). Not touched by this PR.
  - `python -m ruff check` → all checks passed
  - `python scripts/quality_gate.py --mode fast` → same two pre-existing FAILs as `main` (mypy typed-core, pytest); no new gate failures.
  - One existing test needed a one-line update: `test_infer_speaker_turns_raises_helpful_error_when_dependency_missing` stubs `_load_pyannote_pipeline` with a zero-arg function, and that private function now takes `device`.

- **Benchmarks:** M5 Max 128GB, 265s Chinese/English meeting audio, `pyannote/speaker-diarization-community-1`, `mlx-community/Qwen3-ASR-1.7B-8bit`, `--diarize --num-speakers 8`

  | `--diarize-device` | end-to-end | diarization stage |
  |---|---|---|
  | `cpu` | 133s | 117.5s |
  | `mps` | **21s** | **4.4s** (26.7x) |

  **Output is unchanged, not merely similar:** 786/786 segments are identical across the two devices — same boundaries, same eight speaker labels. Verified twice: once by comparing the emitted JSON segment-by-segment, and once by diffing the pyannote annotations directly on a 0.1s grid (100.00% frame-level speaker agreement).

## Agent Memory

- [x] Non-trivial and meaningful work was logged in `docs/memory/events/2026-08.md`
- [ ] `docs/memory/operating-memory.md` updated if active guidance changed — not needed; this adds a feature, it does not change active guidance
- Event IDs referenced in this PR: `MEM-2026-08-24-001`

## Reuse Next Time

When adding a device knob to a cached resource, the cache key must include the device and resolution must happen before the lookup — otherwise the first caller's device silently wins for every later caller. And establish the test baseline on a clean checkout before diagnosing: this branch first showed 8 failures, but `main` already had 1, which isolated the 7 real regressions immediately instead of sending me hunting through all 8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `pyannote` diarization on accelerators via `--diarize-device {auto,cpu,mps,cuda}` (default `auto`). Previously CPU-only; now `auto` prefers MPS, then CUDA, else CPU, reducing wall-clock on GPU/MPS hosts without changing transcripts.

- Device-aware caching: cache key now includes `(model_id, token, device)`; preflight warms the same device to avoid cross-device reuse and double loads.
- Robust fallback: move pipeline with `.to(device)`; on accelerator failure warn, recover to CPU before caching, and memoize the failed `(model_id, token, device)` to avoid repeated retries; if CPU recovery fails, raise and cache nothing.
- Torch stays lazy: CPU path is `torch`-free; missing `torch` resolves to CPU to keep `pyannote.audio`’s actionable ImportError.
- API wiring: threads `diarization_device` through all entry points (`transcribe`, `transcribe_async`, `transcribe_batch`, `Session.transcribe`, `Session.transcribe_async`) and CLI; fixes a bug where `Session` dropped the requested device before resolving config; CLI preflight now takes `--diarize-device`.

**Migration**
- If tests or extensions stub `_load_pyannote_pipeline`, update the stub to accept a `device` argument.
- If you stub CLI preflight helpers (`_preflight_diarization_runtime`, `_ensure_diarization_backend_ready`), update them to accept a `device` argument.

<sup>Written for commit f14bd152b1ad2656bea7b077a9d6002a53dec414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/mlx-qwen3-asr/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable diarization device selection across CLI, transcription, batch, and session APIs.
  * Supports automatic selection and explicit CPU, MPS, or CUDA options.
  * Added device-aware pipeline reuse for improved performance.

* **Bug Fixes**
  * Automatically falls back to CPU when an accelerator is unavailable or cannot be used.
  * Improved recovery and reliability across supported hardware configurations.
  * Added validation and regression coverage for device selection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->