### PR TITLE
fix(server): load the model on the thread that runs inference (#16)

### DIFF
--- a/mlx_qwen3_asr/server.py
+++ b/mlx_qwen3_asr/server.py
@@ -9,6 +9,7 @@ Usage::
 """
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import tempfile
 import time
@@ -117,6 +118,9 @@ class _AppState:
     start_time: float = 0.0
     api_keys_set: set[str] = field(default_factory=set)
     session: object = None  # Session instance
+    # 推論専用のシングルスレッド。MLX のストリームはスレッドローカルなので、
+    # モデルのロードと推論は必ず同じスレッドで行う必要がある。
+    executor: object = None  # ThreadPoolExecutor(max_workers=1)
     config: Optional[ServerConfig] = None
     inference_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     sync_inflight: int = 0  # count of /v1 requests waiting for inference
@@ -207,6 +211,7 @@ def create_app(config: ServerConfig):
                 context=job.context,
                 return_timestamps=job.timestamps,
                 return_chunks=True,
+                executor=state.executor,
             )
         return _result_to_dict(result)
 
@@ -242,7 +247,16 @@ def create_app(config: ServerConfig):
             "bfloat16": mx.bfloat16,
         }
         dtype = dtype_map.get(config.dtype, mx.float16)
-        state.session = Session(config.model, dtype=dtype)
+        # MLX streams are thread-local: the model must be loaded on the very
+        # thread that will later run inference, so both happen on this
+        # single-worker executor. Loading here and inferring on a different
+        # thread fails with "There is no Stream(gpu, N) in current thread."
+        state.executor = ThreadPoolExecutor(max_workers=1,
+                                            thread_name_prefix="mlx-asr")
+        loop = asyncio.get_running_loop()
+        state.session = await loop.run_in_executor(
+            state.executor, lambda: Session(config.model, dtype=dtype)
+        )
         logger.info("Model loaded: %s", config.model)
 
         worker_task = asyncio.create_task(_job_worker())
@@ -252,6 +266,7 @@ def create_app(config: ServerConfig):
 
         worker_task.cancel()
         sweeper_task.cancel()
+        state.executor.shutdown(wait=False)
         # Await cancellation to ensure cleanup runs
         for task in (worker_task, sweeper_task):
             try:
@@ -531,6 +546,7 @@ def create_app(config: ServerConfig):
                     context=prompt or "",
                     return_timestamps=need_timestamps,
                     return_chunks=True,
+                    executor=state.executor,
                 )
         except Exception as exc:
             raise HTTPException(

--- a/mlx_qwen3_asr/session.py
+++ b/mlx_qwen3_asr/session.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, Union
 
 import mlx.core as mx
@@ -152,8 +154,17 @@ class Session:
         num_draft_tokens: int = 4,
         verbose: bool = False,
         on_progress: Optional[ProgressCallback] = None,
+        executor: Optional[ThreadPoolExecutor] = None,
     ) -> TranscriptionResult:
-        """Async wrapper for ``transcribe`` using ``asyncio.to_thread``."""
+        """Async wrapper for ``transcribe`` that offloads to a worker thread.
+
+        MLX streams are thread-local, so the thread that runs inference must be
+        the same thread the model was loaded on. Callers that load the model on a
+        dedicated thread (see ``server.py``) must pass that thread's ``executor``
+        here; otherwise ``asyncio.to_thread`` picks an arbitrary worker from the
+        default pool and inference fails with
+        ``There is no Stream(gpu, N) in current thread.``
+        """
         options = _build_transcribe_options(
             context=context,
             language=language,
@@ -170,12 +181,16 @@ class Session:
             verbose=verbose,
             on_progress=on_progress,
         )
-        return await asyncio.to_thread(
+        call = functools.partial(
             self.transcribe,
             audio,
             draft_model=draft_model,
             **_transcribe_options_to_kwargs(options, include_dtype=False),
         )
+        if executor is None:
+            return await asyncio.to_thread(call)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(executor, call)
 
     def init_streaming(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1365,3 +1365,95 @@ async def test_openai_verbose_json_no_segments():
         assert data["text"] == "Hello"
         assert "words" not in data
         assert "segments" not in data
+
+
+# ---------------------------------------------------------------------------
+# Regression: MLX streams are thread-local (issue #16)
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceThreadAffinity:
+    """The model must be loaded on the same thread that runs inference.
+
+    MLX streams are thread-local. Loading the model on the event-loop thread and
+    then running inference on an arbitrary ``asyncio.to_thread`` worker makes
+    every transcription fail with
+    ``There is no Stream(gpu, N) in current thread.`` (issue #16).
+    """
+
+    @pytest.mark.asyncio
+    async def test_model_is_loaded_on_the_inference_thread(self):
+        import threading
+
+        from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+        seen: dict[str, int] = {}
+
+        class _ThreadRecordingSession:
+            def __init__(self, *args, **kwargs):
+                seen["load"] = threading.get_ident()
+
+            def transcribe(self, *args, **kwargs):
+                seen["infer"] = threading.get_ident()
+                return TranscriptionResult(text="ok", language="English")
+
+            async def transcribe_async(self, audio, *, executor=None, **kwargs):
+                # Mirrors the real Session: dispatch onto the caller's executor.
+                call = lambda: self.transcribe(audio, **kwargs)  # noqa: E731
+                if executor is None:
+                    return await asyncio.to_thread(call)
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(executor, call)
+
+        config = ServerConfig(api_keys=["testkey"])
+        app = create_app(config)
+
+        with patch("mlx_qwen3_asr.session.Session", _ThreadRecordingSession):
+            async with app.router.lifespan_context(app):
+                state = app.state.server
+                assert state.executor is not None, "lifespan must create an executor"
+                await state.session.transcribe_async(
+                    "dummy.wav", executor=state.executor
+                )
+
+        assert seen["load"] == seen["infer"], (
+            "model was loaded on a different thread than the one running "
+            "inference — this is exactly the condition that raises "
+            "'There is no Stream(gpu, N) in current thread.'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_executor_is_single_threaded(self):
+        """Inference must be serialized onto one thread, not a pool."""
+        import threading
+
+        from mlx_qwen3_asr.transcribe import TranscriptionResult
+
+        threads: set[int] = set()
+
+        class _Session:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def transcribe(self, *args, **kwargs):
+                threads.add(threading.get_ident())
+                return TranscriptionResult(text="ok", language="English")
+
+            async def transcribe_async(self, audio, *, executor=None, **kwargs):
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(
+                    executor, lambda: self.transcribe(audio)
+                )
+
+        config = ServerConfig(api_keys=["testkey"])
+        app = create_app(config)
+
+        with patch("mlx_qwen3_asr.session.Session", _Session):
+            async with app.router.lifespan_context(app):
+                state = app.state.server
+                await asyncio.gather(*[
+                    state.session.transcribe_async("d.wav", executor=state.executor)
+                    for _ in range(8)
+                ])
+
+        assert len(threads) == 1, f"expected 1 inference thread, saw {len(threads)}"


### PR DESCRIPTION
Fixes #16.

## What happens

Every request to the HTTP server fails, while the CLI on the same machine works:

```
$ curl -X POST http://127.0.0.1:8765/v1/audio/transcriptions \
    -H "Authorization: Bearer ..." -F "file=@ja.wav"
{"error":{"message":"There is no Stream(gpu, 1) in current thread.", ...}}
```

Both endpoints are affected — the OpenAI-compatible one and the async `/transcribe` job API — so it is not specific to either route.

## Root cause

MLX streams are thread-local. `lifespan` builds the `Session` on the event-loop thread, but inference goes through `Session.transcribe_async`, which offloads to an arbitrary worker from `asyncio.to_thread`'s default pool. The mismatch surfaces the moment a value is pulled back into Python — in practice at `mx.argmax(logits).item()` in `generate.py`:

```
File "mlx_qwen3_asr/session.py", line 119, in transcribe
File "mlx_qwen3_asr/transcribe.py", line 743, in _transcribe_loaded_components
File "mlx_qwen3_asr/generate.py", line 210, in generate_with_info
File "mlx_qwen3_asr/generate.py", line 502, in _sample
    return mx.argmax(logits).item()
RuntimeError: There is no Stream(gpu, 1) in current thread.
```

The part worth calling out: **moving inference onto a dedicated thread is not sufficient.** I measured all four combinations against a real model on an M1 Max:

| model loaded on | inference runs on | result |
| --- | --- | --- |
| main thread | main thread (CLI) | OK |
| main thread | `asyncio.to_thread` | **fails** |
| main thread | dedicated single thread | **fails** |
| dedicated single thread | that same thread | OK |

So the model has to be *loaded* on the thread that will later run it.

## The fix

`lifespan` creates a single-worker `ThreadPoolExecutor`, constructs the `Session` inside it, and both call sites hand that executor to `transcribe_async`, which gained an optional `executor` argument. It still defaults to `asyncio.to_thread`, so `Session` used directly is unchanged.

A single worker is not a throughput regression: the server already serializes inference behind `inference_lock`.

## Tests

Two regression tests in `TestInferenceThreadAffinity`, both of which fail on `main`:

- `test_model_is_loaded_on_the_inference_thread` — asserts the load thread and the inference thread are the same
- `test_executor_is_single_threaded` — asserts 8 concurrent requests land on exactly one thread

```
603 passed, 1 skipped
```

Also verified end-to-end with real MLX (M1 Max, Qwen3-ASR-1.7B 8-bit): both endpoints return transcripts instead of 500s.

## Environment

macOS 14.7 (Darwin 23.6.0), M1 Max, Python 3.12, mlx 0.32.2 / mlx-metal 0.32.2, mlx-qwen3-asr 0.3.5. Also reproduced on mlx 0.31.2, so it is not a regression from a recent MLX release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the HTTP server rejecting every transcription request because MLX streams are thread-local: the model loaded on the event-loop thread while inference ran on a different worker thread, failing with `There is no Stream(gpu, 1) in current thread.`

- `lifespan` now creates a single-worker `ThreadPoolExecutor` and loads the `Session` inside it, so loading and inference share the same thread.
- Both the OpenAI-compatible endpoint and the async `/transcribe` job API hand that executor to `transcribe_async`.
- `transcribe_async` gained an optional `executor` argument, still defaulting to `asyncio.to_thread` so direct `Session` use is unchanged.
- A single worker costs no throughput because the server already serializes inference behind `inference_lock`.
- Adds two regression tests asserting the model loads on the inference thread and that concurrent requests run on exactly one thread.

<sup>Written for commit f6ae71d02d7dd7d3dfd78ea7f96680acdd5393b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/mlx-qwen3-asr/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription reliability by ensuring model loading and inference run on the same dedicated processing thread.
  * Prevented thread-related MLX errors during concurrent transcription requests.
* **Tests**
  * Added regression coverage confirming consistent model and inference thread usage.
  * Added validation that concurrent requests are safely processed through a single inference thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->